### PR TITLE
feat: add shell installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,18 +24,17 @@ Driftr manages Node.js versions so you don't have to think about them. Pin a ver
 - **Secure** -- SHA256 checksum verification on every download
 - **Simple** -- six commands cover the entire workflow
 
+## Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/DriftrLabs/driftr/main/install.sh | sh
+```
+
+This downloads the latest release, verifies its checksum, and configures your PATH. See [docs/installation.md](docs/installation.md) for alternative methods.
+
 ## Quick Start
 
 ```bash
-# Build from source
-go build -o driftr ./cmd/driftr/
-
-# Initialize directories and shims
-driftr setup
-
-# Add shims to your PATH (add to ~/.zshrc or ~/.bashrc)
-export PATH="$HOME/.driftr/bin:$PATH"
-
 # Install Node.js
 driftr install node@22
 
@@ -112,9 +111,10 @@ The shim in `~/.driftr/bin/node` intercepts calls, the resolver determines the c
 
 ## Requirements
 
-- Go 1.23+ (to build from source)
 - macOS or Linux
+- `curl` or `wget` (for the install script)
 - Internet access (to download Node.js releases from nodejs.org)
+- Go 1.23+ (only if building from source)
 
 ## License
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,5 +1,42 @@
 # Installation
 
+## Quick Install (recommended)
+
+Run the installer script to download the latest release, verify its checksum, and set up your PATH:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/DriftrLabs/driftr/main/install.sh | sh
+```
+
+The script:
+
+1. Detects your OS and architecture
+2. Downloads the latest binary from GitHub Releases
+3. Verifies the SHA256 checksum
+4. Installs to `~/.driftr/bin/`
+5. Runs `driftr setup` to create directories and shims
+6. Adds `~/.driftr/bin` to your PATH
+
+### Options
+
+Pin a specific version:
+
+```bash
+DRIFTR_VERSION=0.1.0 curl -fsSL https://raw.githubusercontent.com/DriftrLabs/driftr/main/install.sh | sh
+```
+
+Override the install directory:
+
+```bash
+DRIFTR_INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/DriftrLabs/driftr/main/install.sh | sh
+```
+
+### Using wget
+
+```bash
+wget -qO- https://raw.githubusercontent.com/DriftrLabs/driftr/main/install.sh | sh
+```
+
 ## Building from Source
 
 Driftr is written in Go. You need Go 1.23 or later to build it.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,197 @@
+#!/bin/sh
+# Driftr installer — downloads the latest release from GitHub and sets up PATH.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/DriftrLabs/driftr/main/install.sh | sh
+#
+# Environment variables:
+#   DRIFTR_VERSION     — pin a specific version (e.g. "0.1.0"), default: latest
+#   DRIFTR_INSTALL_DIR — override install directory, default: ~/.driftr/bin
+
+set -eu
+
+REPO="DriftrLabs/driftr"
+DEFAULT_INSTALL_DIR="$HOME/.driftr/bin"
+INSTALL_DIR="${DRIFTR_INSTALL_DIR:-$DEFAULT_INSTALL_DIR}"
+
+# --- helpers ----------------------------------------------------------------
+
+log() {
+    printf '%s\n' "$@"
+}
+
+err() {
+    log "error: $*" >&2
+    exit 1
+}
+
+need() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        err "$1 is required but not found"
+    fi
+}
+
+# Download a URL to a local file. Prefers curl, falls back to wget.
+download() {
+    url="$1"
+    dest="$2"
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL -o "$dest" "$url"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -qO "$dest" "$url"
+    else
+        err "curl or wget is required"
+    fi
+}
+
+# Download a URL and print to stdout.
+download_stdout() {
+    url="$1"
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL "$url"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -qO- "$url"
+    else
+        err "curl or wget is required"
+    fi
+}
+
+# --- detect platform --------------------------------------------------------
+
+detect_os() {
+    os="$(uname -s)"
+    case "$os" in
+        Linux*)  echo "linux" ;;
+        Darwin*) echo "darwin" ;;
+        *)       err "unsupported OS: $os" ;;
+    esac
+}
+
+detect_arch() {
+    arch="$(uname -m)"
+    case "$arch" in
+        x86_64|amd64)  echo "amd64" ;;
+        aarch64|arm64) echo "arm64" ;;
+        *)             err "unsupported architecture: $arch" ;;
+    esac
+}
+
+# --- resolve version --------------------------------------------------------
+
+resolve_version() {
+    if [ -n "${DRIFTR_VERSION:-}" ]; then
+        # Strip leading "v" if present.
+        echo "$DRIFTR_VERSION" | sed 's/^v//'
+        return
+    fi
+
+    tag=$(download_stdout "https://api.github.com/repos/${REPO}/releases/latest" \
+        | grep '"tag_name"' \
+        | sed -E 's/.*"tag_name":\s*"v?([^"]+)".*/\1/')
+
+    if [ -z "$tag" ]; then
+        err "could not determine latest version (GitHub API rate limit?)"
+    fi
+
+    echo "$tag"
+}
+
+# --- checksum verification --------------------------------------------------
+
+verify_checksum() {
+    archive="$1"
+    checksums_file="$2"
+    filename="$(basename "$archive")"
+
+    expected=$(grep "$filename" "$checksums_file" | awk '{print $1}')
+    if [ -z "$expected" ]; then
+        err "no checksum found for $filename in checksums.txt"
+    fi
+
+    if command -v sha256sum >/dev/null 2>&1; then
+        actual=$(sha256sum "$archive" | awk '{print $1}')
+    elif command -v shasum >/dev/null 2>&1; then
+        actual=$(shasum -a 256 "$archive" | awk '{print $1}')
+    else
+        err "sha256sum or shasum is required for checksum verification"
+    fi
+
+    if [ "$actual" != "$expected" ]; then
+        err "checksum mismatch for $filename (expected $expected, got $actual)"
+    fi
+}
+
+# --- main -------------------------------------------------------------------
+
+main() {
+    need tar
+    need uname
+
+    os=$(detect_os)
+    arch=$(detect_arch)
+    version=$(resolve_version)
+
+    archive_name="driftr_${version}_${os}_${arch}.tar.gz"
+    base_url="https://github.com/${REPO}/releases/download/v${version}"
+
+    log "Installing driftr v${version} (${os}/${arch})..."
+
+    tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' EXIT
+
+    log "Downloading ${archive_name}..."
+    download "${base_url}/${archive_name}" "${tmpdir}/${archive_name}"
+    download "${base_url}/checksums.txt" "${tmpdir}/checksums.txt"
+
+    log "Verifying checksum..."
+    verify_checksum "${tmpdir}/${archive_name}" "${tmpdir}/checksums.txt"
+
+    log "Extracting..."
+    tar -xzf "${tmpdir}/${archive_name}" -C "$tmpdir"
+
+    mkdir -p "$INSTALL_DIR"
+    cp "${tmpdir}/driftr" "${INSTALL_DIR}/driftr"
+    chmod +x "${INSTALL_DIR}/driftr"
+
+    log "Installed driftr to ${INSTALL_DIR}/driftr"
+
+    # Run setup to create directories and generate shims.
+    "${INSTALL_DIR}/driftr" setup
+
+    # Configure PATH in shell profile if not already present.
+    configure_path
+
+    log ""
+    log "driftr v${version} installed successfully!"
+    log ""
+    log "Restart your shell or run:"
+    log "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+}
+
+configure_path() {
+    path_line="export PATH=\"${INSTALL_DIR}:\$PATH\""
+
+    # Detect the user's shell profile.
+    shell_name="$(basename "${SHELL:-/bin/sh}")"
+    case "$shell_name" in
+        zsh)  profile="$HOME/.zshrc" ;;
+        bash)
+            if [ -f "$HOME/.bashrc" ]; then
+                profile="$HOME/.bashrc"
+            else
+                profile="$HOME/.bash_profile"
+            fi
+            ;;
+        *)    profile="$HOME/.profile" ;;
+    esac
+
+    # Don't duplicate the entry.
+    if [ -f "$profile" ] && grep -qF "$INSTALL_DIR" "$profile"; then
+        return
+    fi
+
+    printf '\n# Driftr\n%s\n' "$path_line" >> "$profile"
+    log "Added ${INSTALL_DIR} to PATH in ${profile}"
+}
+
+main


### PR DESCRIPTION
## Summary

- Add `install.sh` — a POSIX-compatible shell script for one-liner installation (`curl | sh`), similar to Volta and Mise
- The script downloads the latest release from GitHub, verifies SHA256 checksum, installs the binary, runs `driftr setup`, and configures PATH
- Supports `DRIFTR_VERSION` and `DRIFTR_INSTALL_DIR` environment variables for customization
- Update README.md with install one-liner and reorder Quick Start
- Update docs/installation.md with the script as the primary install method

## Test plan

- [ ] Run `shellcheck install.sh` for lint issues
- [ ] Test on macOS (arm64) with a published release tag
- [ ] Test on Linux (amd64) with a published release tag
- [ ] Test `DRIFTR_VERSION` env var to pin a specific version
- [ ] Verify checksum failure is caught (corrupt archive)
- [ ] Verify PATH is appended to shell profile only once