### PR TITLE
fix: clean up temp files and partial installs on SIGINT

### DIFF
--- a/internal/installer/cleanup_test.go
+++ b/internal/installer/cleanup_test.go
@@ -1,0 +1,141 @@
+package installer
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func TestInstallCleanup_RemovesTmpFile(t *testing.T) {
+	tmpFile, err := os.CreateTemp(t.TempDir(), "driftr-download-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+
+	cleanup := &installCleanup{}
+	cleanup.setTmpFile(tmpPath)
+	cleanup.run()
+
+	if _, err := os.Stat(tmpPath); !os.IsNotExist(err) {
+		t.Errorf("temp file should have been removed: %s", tmpPath)
+	}
+}
+
+func TestInstallCleanup_RemovesVersionDir(t *testing.T) {
+	// Point HOME to a temp dir so platform.NodeVersionDir resolves there.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Create a fake version directory structure under ~/.driftr/tools/node/99.0.0.
+	versionDir := filepath.Join(home, ".driftr", "tools", "node", "99.0.0")
+	binDir := filepath.Join(versionDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "node"), []byte("fake"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cleanup := &installCleanup{version: "99.0.0"}
+	cleanup.run()
+
+	if _, err := os.Stat(versionDir); !os.IsNotExist(err) {
+		t.Errorf("version directory should have been removed: %s", versionDir)
+	}
+}
+
+func TestInstallCleanup_RemovesBothTmpFileAndVersionDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Create temp file.
+	tmpFile, err := os.CreateTemp(t.TempDir(), "driftr-download-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+
+	// Create version dir.
+	versionDir := filepath.Join(home, ".driftr", "tools", "node", "99.0.0")
+	if err := os.MkdirAll(versionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cleanup := &installCleanup{}
+	cleanup.setTmpFile(tmpPath)
+	cleanup.setVersion("99.0.0")
+	cleanup.run()
+
+	if _, err := os.Stat(tmpPath); !os.IsNotExist(err) {
+		t.Errorf("temp file should have been removed")
+	}
+	if _, err := os.Stat(versionDir); !os.IsNotExist(err) {
+		t.Errorf("version directory should have been removed")
+	}
+}
+
+func TestInstallCleanup_RunIdempotent(t *testing.T) {
+	tmpFile, err := os.CreateTemp(t.TempDir(), "driftr-download-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+
+	cleanup := &installCleanup{}
+	cleanup.setTmpFile(tmpPath)
+
+	// Call run twice — should not panic or error.
+	cleanup.run()
+	cleanup.run()
+
+	if _, err := os.Stat(tmpPath); !os.IsNotExist(err) {
+		t.Errorf("temp file should have been removed")
+	}
+}
+
+func TestInstallCleanup_ConcurrentAccess(t *testing.T) {
+	cleanup := &installCleanup{}
+
+	var wg sync.WaitGroup
+	// Hammer set/clear/run concurrently to test for races.
+	for i := 0; i < 50; i++ {
+		wg.Add(3)
+		go func() {
+			defer wg.Done()
+			cleanup.setTmpFile("/tmp/fake")
+		}()
+		go func() {
+			defer wg.Done()
+			cleanup.clearTmpFile()
+		}()
+		go func() {
+			defer wg.Done()
+			cleanup.run()
+		}()
+	}
+	wg.Wait()
+}
+
+func TestInstallCleanup_ClearPreventsRemoval(t *testing.T) {
+	tmpFile, err := os.CreateTemp(t.TempDir(), "driftr-download-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+
+	cleanup := &installCleanup{}
+	cleanup.setTmpFile(tmpPath)
+	cleanup.clearTmpFile()
+	cleanup.run()
+
+	// File should still exist since we cleared it before running cleanup.
+	if _, err := os.Stat(tmpPath); err != nil {
+		t.Errorf("temp file should NOT have been removed after clearTmpFile")
+	}
+}

--- a/internal/installer/download.go
+++ b/internal/installer/download.go
@@ -30,7 +30,8 @@ func ArchiveFilename(version string) string {
 
 // Download fetches the Node.js archive to the cache directory.
 // Returns the path to the downloaded file.
-func Download(version string, verbose bool) (string, error) {
+// If cleanup is non-nil, the temp file path is registered for signal-safe removal.
+func Download(version string, verbose bool, cleanup *installCleanup) (string, error) {
 	cacheDir, err := platform.CacheDir()
 	if err != nil {
 		return "", err
@@ -75,16 +76,32 @@ func Download(version string, verbose bool) (string, error) {
 	}
 	tmpPath := tmpFile.Name()
 
+	// Register temp file for signal-safe cleanup.
+	if cleanup != nil {
+		cleanup.setTmpFile(tmpPath)
+	}
+
 	_, err = io.Copy(tmpFile, resp.Body)
 	tmpFile.Close()
 	if err != nil {
 		os.Remove(tmpPath)
+		if cleanup != nil {
+			cleanup.clearTmpFile()
+		}
 		return "", fmt.Errorf("download interrupted: %w", err)
 	}
 
 	if err := os.Rename(tmpPath, destPath); err != nil {
 		os.Remove(tmpPath)
+		if cleanup != nil {
+			cleanup.clearTmpFile()
+		}
 		return "", fmt.Errorf("failed to save archive: %w", err)
+	}
+
+	// Temp file has been renamed to final path — no longer needs cleanup.
+	if cleanup != nil {
+		cleanup.clearTmpFile()
 	}
 
 	return destPath, nil

--- a/internal/installer/node.go
+++ b/internal/installer/node.go
@@ -5,11 +5,62 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"os/signal"
 	"strings"
+	"sync"
+	"syscall"
 
 	"github.com/DriftrLabs/driftr/internal/platform"
 	"github.com/DriftrLabs/driftr/internal/version"
 )
+
+// installCleanup tracks resources that need cleanup if the install is
+// interrupted by a signal. All fields are guarded by mu.
+type installCleanup struct {
+	mu      sync.Mutex
+	tmpFile string // temp download file (driftr-download-*)
+	version string // version being installed (partial extraction dir)
+	verbose bool
+}
+
+func (c *installCleanup) setTmpFile(path string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.tmpFile = path
+}
+
+func (c *installCleanup) clearTmpFile() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.tmpFile = ""
+}
+
+func (c *installCleanup) setVersion(v string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.version = v
+}
+
+// run removes any tracked temp files and partial installs.
+// Safe to call multiple times or concurrently.
+func (c *installCleanup) run() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.tmpFile != "" {
+		os.Remove(c.tmpFile)
+		c.tmpFile = ""
+	}
+	if c.version != "" {
+		dir, err := platform.NodeVersionDir(c.version)
+		if err == nil {
+			if c.verbose {
+				fmt.Fprintf(os.Stderr, "  Cleaning up partial install: %s\n", dir)
+			}
+			os.RemoveAll(dir)
+		}
+		c.version = ""
+	}
+}
 
 const nodeIndexURL = "https://nodejs.org/dist/index.json"
 
@@ -52,36 +103,49 @@ func Install(versionStr string, verbose bool) (string, error) {
 		return resolvedVersion, nil
 	}
 
-	archivePath, err := Download(resolvedVersion, verbose)
+	// Set up signal-aware cleanup for temp files and partial installs.
+	cleanup := &installCleanup{verbose: verbose}
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-sigChan:
+			fmt.Fprintf(os.Stderr, "\nInterrupted, cleaning up...\n")
+			cleanup.run()
+			os.Exit(1)
+		case <-done:
+		}
+	}()
+	defer func() {
+		signal.Stop(sigChan)
+		close(done)
+	}()
+
+	cleanup.setVersion(resolvedVersion)
+
+	archivePath, err := Download(resolvedVersion, verbose, cleanup)
 	if err != nil {
+		cleanup.run()
 		return "", err
 	}
 
 	if err := VerifyChecksum(archivePath, resolvedVersion, verbose); err != nil {
 		// Remove corrupted cached archive so next attempt re-downloads.
 		os.Remove(archivePath)
+		cleanup.run()
 		return "", fmt.Errorf("checksum verification failed: %w", err)
 	}
 
 	if err := Extract(archivePath, resolvedVersion, verbose); err != nil {
-		// Clean up partial extraction so it doesn't look installed.
-		cleanupFailedInstall(resolvedVersion, verbose)
+		cleanup.run()
 		return "", err
 	}
 
-	return resolvedVersion, nil
-}
+	// Success — nothing to clean up.
+	cleanup.setVersion("")
 
-// cleanupFailedInstall removes a partially extracted version directory.
-func cleanupFailedInstall(version string, verbose bool) {
-	dir, err := platform.NodeVersionDir(version)
-	if err != nil {
-		return
-	}
-	if verbose {
-		fmt.Printf("  Cleaning up partial install: %s\n", dir)
-	}
-	os.RemoveAll(dir)
+	return resolvedVersion, nil
 }
 
 // resolveLatestVersion finds the latest Node.js release matching a partial version.


### PR DESCRIPTION
## Summary

- Add signal handler in `Install()` that catches SIGINT/SIGTERM and removes orphaned temp download files (`driftr-download-*`) and partial version directories before exiting
- Track cleanup targets in a mutex-guarded `installCleanup` struct shared between the signal handler goroutine and the install flow
- Register/clear temp file path in `Download()` around the critical window between `CreateTemp` and `Rename`

Closes #10

## Test plan

- [x] Unit tests for `installCleanup`: removes tmp files, version dirs, both, idempotent, concurrent-safe, clear prevents removal
- [x] All tests pass with `-race` detector
- [ ] Manual: run `driftr install node@24`, press Ctrl+C during download — verify no `driftr-download-*` files left in `~/.driftr/cache/`
- [ ] Manual: run `driftr install node@24`, press Ctrl+C during extraction — verify no partial dir in `~/.driftr/tools/node/`