### PR TITLE
perf: bypass cobra on shim hot path

### DIFF
--- a/cmd/driftr/main.go
+++ b/cmd/driftr/main.go
@@ -1,7 +1,29 @@
 package main
 
-import "github.com/DriftrLabs/driftr/internal/cli"
+import (
+	"fmt"
+	"os"
+
+	"github.com/DriftrLabs/driftr/internal/cli"
+	"github.com/DriftrLabs/driftr/internal/process"
+	"github.com/DriftrLabs/driftr/internal/resolver"
+)
 
 func main() {
+	// Fast path: bypass Cobra entirely for shim invocations.
+	// Shim scripts call "driftr shim <tool> [args...]".
+	if len(os.Args) >= 3 && os.Args[1] == "shim" {
+		tool := os.Args[2]
+		binPath, err := resolver.ResolveBinary(tool, "")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "driftr: %s\n", err)
+			os.Exit(1)
+		}
+		if err := process.Exec(binPath, os.Args[3:]); err != nil {
+			fmt.Fprintf(os.Stderr, "driftr: %s\n", err)
+			os.Exit(1)
+		}
+	}
+
 	cli.Execute()
 }


### PR DESCRIPTION
## Summary

- Add a short-circuit in `main()` that detects `driftr shim <tool>` and calls `resolver.ResolveBinary()` + `process.Exec()` directly, bypassing all Cobra initialization
- No second binary needed — same `driftr` binary, just a fast path before `cli.Execute()`
- Shim scripts remain unchanged (they already call `driftr shim <tool>`)
- The Cobra `shim` subcommand is kept as fallback for edge cases (`driftr shim` with no args)

Closes #7

## Test plan

- [x] All tests pass with `-race`
- [ ] Manual: `driftr setup && ~/.driftr/bin/node -v` resolves and runs correctly
- [ ] Benchmark with `hyperfine` before/after to quantify latency improvement