### PR TITLE
chore: drop Windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: bash
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -51,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,7 +8,6 @@ builds:
     goos:
       - linux
       - darwin
-      - windows
     goarch:
       - amd64
       - arm64
@@ -22,9 +21,6 @@ archives:
   - format: tar.gz
     name_template: >-
       {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
-    format_overrides:
-      - goos: windows
-        format: zip
 
 checksum:
   name_template: checksums.txt

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -49,9 +49,6 @@ func NodeBinary(version string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if runtime.GOOS == "windows" {
-		return filepath.Join(dir, "node.exe"), nil
-	}
 	return filepath.Join(dir, "bin", "node"), nil
 }
 
@@ -61,9 +58,6 @@ func NpmBinary(version string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if runtime.GOOS == "windows" {
-		return filepath.Join(dir, "npm.cmd"), nil
-	}
 	return filepath.Join(dir, "bin", "npm"), nil
 }
 
@@ -72,9 +66,6 @@ func NpxBinary(version string) (string, error) {
 	dir, err := NodeVersionDir(version)
 	if err != nil {
 		return "", err
-	}
-	if runtime.GOOS == "windows" {
-		return filepath.Join(dir, "npx.cmd"), nil
 	}
 	return filepath.Join(dir, "bin", "npx"), nil
 }
@@ -141,8 +132,6 @@ func OS() string {
 		return "darwin"
 	case "linux":
 		return "linux"
-	case "windows":
-		return "win"
 	default:
 		return runtime.GOOS
 	}
@@ -164,8 +153,5 @@ func ToolBinary(tool, version string) (string, error) {
 
 // ArchiveExt returns the archive extension for the current platform.
 func ArchiveExt() string {
-	if runtime.GOOS == "windows" {
-		return "zip"
-	}
 	return "tar.gz"
 }

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 
 	"github.com/DriftrLabs/driftr/internal/platform"
 )
@@ -12,9 +11,8 @@ import (
 // shimTools lists the tools for which shims are created in MVP.
 var shimTools = []string{"node", "npm", "npx"}
 
-// GenerateShims creates shim scripts/binaries in ~/.driftr/bin/.
-// On Unix, these are shell scripts that invoke `driftr shim <tool>`.
-// On Windows, these would be .cmd files (future).
+// GenerateShims creates shim shell scripts in ~/.driftr/bin/.
+// Each shim invokes `driftr shim <tool>` to resolve and exec the real binary.
 func GenerateShims() error {
 	binDir, err := platform.BinDir()
 	if err != nil {
@@ -46,12 +44,6 @@ func GenerateShims() error {
 
 func writeShim(binDir, tool, driftrBin string) error {
 	shimPath := filepath.Join(binDir, tool)
-
-	if runtime.GOOS == "windows" {
-		shimPath += ".cmd"
-		content := fmt.Sprintf("@echo off\r\n\"%s\" shim %s %%*\r\n", driftrBin, tool)
-		return os.WriteFile(shimPath, []byte(content), 0o755)
-	}
 
 	content := fmt.Sprintf(`#!/bin/sh
 exec "%s" shim %s "$@"


### PR DESCRIPTION
## Summary

- Remove `windows-latest` from CI test and build matrices
- Remove Windows build target and zip format override from GoReleaser
- Remove Windows-specific code: `.exe`/`.cmd` binary paths, `.cmd` shim generation, `"win"` OS mapping, `"zip"` archive extension
- Remove unused `runtime` import from shim package

This fixes the CI failures on `main` — the cleanup tests use `t.Setenv("HOME", ...)` which doesn't affect `os.UserHomeDir()` on Windows (which reads `USERPROFILE`).

## Test plan

- [x] All tests pass locally with `-race`
- [x] Builds cleanly
- [ ] CI passes on ubuntu + macos (no more windows-latest failures)