### PR TITLE
fix: add depth limit to project config directory walk

### DIFF
--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -149,6 +149,8 @@ func resolveExplicit(ver string) (*Resolution, error) {
 	}, nil
 }
 
+const maxResolveDepth = 20
+
 func resolveFromProject(dir string, verbose bool) (*Resolution, error) {
 	absDir, err := filepath.Abs(dir)
 	if err != nil {
@@ -158,7 +160,14 @@ func resolveFromProject(dir string, verbose bool) (*Resolution, error) {
 	// Walk up directories looking for .driftr.toml or package.json (volta),
 	// checking both in each directory before moving to the parent.
 	current := absDir
+	depth := 0
 	for {
+		if depth >= maxResolveDepth {
+			if verbose {
+				fmt.Printf("  [resolve]   Reached max depth (%d), stopping search\n", maxResolveDepth)
+			}
+			break
+		}
 		// Check .driftr.toml first.
 		cfgPath := filepath.Join(current, config.ProjectConfigFile)
 		if verbose {
@@ -187,6 +196,7 @@ func resolveFromProject(dir string, verbose bool) (*Resolution, error) {
 			return resolveProjectVersion(pkg.Driftr.Node, current, SourcePackageJSON)
 		}
 
+		depth++
 		parent := filepath.Dir(current)
 		if parent == current {
 			break


### PR DESCRIPTION
## Summary
- Adds `maxResolveDepth = 20` constant to cap the upward directory walk in `resolveFromProject()`
- Prevents pathological traversal on deeply nested paths or across filesystem mount boundaries
- Logs a verbose trace message when the limit is reached

Closes #11

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` passes
- [x] Integration tests via Docker (`docker build -f Dockerfile.test -t driftr-test . && docker run --rm driftr-test`)