### PR TITLE
feat: show download progress during node installation

### DIFF
--- a/internal/installer/download.go
+++ b/internal/installer/download.go
@@ -11,6 +11,50 @@ import (
 	"github.com/DriftrLabs/driftr/internal/platform"
 )
 
+// isTerminal reports whether f is connected to a terminal.
+func isTerminal(f *os.File) bool {
+	fi, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+// progressWriter wraps an io.Writer to report download progress to stderr.
+type progressWriter struct {
+	dest      io.Writer
+	total     int64 // from Content-Length; -1 if unknown
+	written   int64
+	lastPrint time.Time
+}
+
+func (pw *progressWriter) Write(p []byte) (int, error) {
+	n, err := pw.dest.Write(p)
+	pw.written += int64(n)
+
+	if time.Since(pw.lastPrint) >= 100*time.Millisecond {
+		pw.printProgress()
+		pw.lastPrint = time.Now()
+	}
+
+	return n, err
+}
+
+func (pw *progressWriter) printProgress() {
+	downloadedMB := float64(pw.written) / (1024 * 1024)
+	if pw.total > 0 {
+		totalMB := float64(pw.total) / (1024 * 1024)
+		fmt.Fprintf(os.Stderr, "\r  Downloading: %.1f MB / %.1f MB", downloadedMB, totalMB)
+	} else {
+		fmt.Fprintf(os.Stderr, "\r  Downloading: %.1f MB", downloadedMB)
+	}
+}
+
+func (pw *progressWriter) finish() {
+	pw.printProgress()
+	fmt.Fprint(os.Stderr, "\n")
+}
+
 const nodeDistBaseURL = "https://nodejs.org/dist"
 
 // httpClient is the shared HTTP client for all installer network operations.
@@ -81,7 +125,13 @@ func Download(version string, verbose bool, cleanup *installCleanup) (string, er
 		cleanup.setTmpFile(tmpPath)
 	}
 
-	_, err = io.Copy(tmpFile, resp.Body)
+	if isTerminal(os.Stderr) {
+		pw := &progressWriter{dest: tmpFile, total: resp.ContentLength}
+		_, err = io.Copy(pw, resp.Body)
+		pw.finish()
+	} else {
+		_, err = io.Copy(tmpFile, resp.Body)
+	}
 	tmpFile.Close()
 	if err != nil {
 		os.Remove(tmpPath)

--- a/internal/installer/download_test.go
+++ b/internal/installer/download_test.go
@@ -1,0 +1,84 @@
+package installer
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"testing"
+)
+
+func TestProgressWriter_CountsBytes(t *testing.T) {
+	var buf bytes.Buffer
+	pw := &progressWriter{dest: &buf, total: 1000}
+
+	data := make([]byte, 500)
+	n, err := pw.Write(data)
+	if err != nil {
+		t.Fatalf("Write() error: %v", err)
+	}
+	if n != 500 {
+		t.Errorf("Write() returned %d, want 500", n)
+	}
+	if pw.written != 500 {
+		t.Errorf("written = %d, want 500", pw.written)
+	}
+
+	n, err = pw.Write(data[:300])
+	if err != nil {
+		t.Fatalf("Write() error: %v", err)
+	}
+	if n != 300 {
+		t.Errorf("Write() returned %d, want 300", n)
+	}
+	if pw.written != 800 {
+		t.Errorf("written = %d, want 800", pw.written)
+	}
+}
+
+func TestProgressWriter_DelegatesToDest(t *testing.T) {
+	var buf bytes.Buffer
+	pw := &progressWriter{dest: &buf, total: -1}
+
+	data := []byte("hello driftr")
+	if _, err := pw.Write(data); err != nil {
+		t.Fatalf("Write() error: %v", err)
+	}
+
+	if got := buf.String(); got != "hello driftr" {
+		t.Errorf("dest received %q, want %q", got, "hello driftr")
+	}
+}
+
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) {
+	return 0, errors.New("disk full")
+}
+
+func TestProgressWriter_PropagatesErrors(t *testing.T) {
+	pw := &progressWriter{dest: errWriter{}, total: 100}
+
+	_, err := pw.Write([]byte("data"))
+	if err == nil {
+		t.Fatal("expected error from Write(), got nil")
+	}
+	if err.Error() != "disk full" {
+		t.Errorf("error = %q, want %q", err.Error(), "disk full")
+	}
+}
+
+func TestIsTerminal_Pipe(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error: %v", err)
+	}
+	defer r.Close()
+	defer w.Close()
+
+	if isTerminal(r) {
+		t.Error("isTerminal(pipe reader) = true, want false")
+	}
+	if isTerminal(w) {
+		t.Error("isTerminal(pipe writer) = true, want false")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds in-place progress reporting (`Downloading: X.X MB / Y.Y MB`) on stderr during Node.js archive downloads
- Uses `\r` carriage return for TTY updates, automatically suppressed on non-TTY (piped output, CI)
- Handles unknown `Content-Length` (-1) by showing bytes only without total
- No new external dependencies — stdlib-only TTY detection via `os.File.Stat()`

Closes #8