### PR TITLE
fix: install script fails on macOS due to non-POSIX sed regex

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -87,7 +87,7 @@ resolve_version() {
 
     tag=$(download_stdout "https://api.github.com/repos/${REPO}/releases/latest" \
         | grep '"tag_name"' \
-        | sed -E 's/.*"tag_name":\s*"v?([^"]+)".*/\1/')
+        | sed -E 's/.*"tag_name": *"v?([^"]+)".*/\1/')
 
     if [ -z "$tag" ]; then
         err "could not determine latest version (GitHub API rate limit?)"


### PR DESCRIPTION
## Summary
- Replaces `\s*` (PCRE) with ` *` (POSIX ERE) in the version-parsing `sed` command
- `\s` is not supported by macOS BSD `sed` even with `-E`, causing the regex to silently fail and pass raw JSON through as the version string