### PR TITLE
fix: resolve partial versions consistently across all commands

### DIFF
--- a/internal/installer/node.go
+++ b/internal/installer/node.go
@@ -81,16 +81,16 @@ func Install(versionStr string, verbose bool) (string, error) {
 		return "", fmt.Errorf("invalid version: %w", err)
 	}
 
-	// If partial version (e.g. "24"), resolve to latest matching release.
+	// If partial version (e.g. "24", "24.14") or "latest", resolve to latest matching release.
 	resolvedVersion := v.String()
-	if v.IsPartial() {
+	if v.Latest || v.IsPartial() {
 		resolved, err := resolveLatestVersion(v)
 		if err != nil {
 			return "", err
 		}
 		resolvedVersion = resolved
 		if verbose {
-			fmt.Printf("  Resolved node@%d to %s\n", v.Major, resolvedVersion)
+			fmt.Printf("  Resolved %s to %s\n", versionStr, resolvedVersion)
 		}
 	}
 
@@ -149,6 +149,7 @@ func Install(versionStr string, verbose bool) (string, error) {
 }
 
 // resolveLatestVersion finds the latest Node.js release matching a partial version.
+// The release index is sorted newest-first, so the first match is the latest.
 func resolveLatestVersion(v version.Version) (string, error) {
 	releases, err := fetchNodeIndex()
 	if err != nil {
@@ -160,12 +161,15 @@ func resolveLatestVersion(v version.Version) (string, error) {
 		if err != nil {
 			continue
 		}
-		if rv.Major == v.Major {
+		if v.Matches(rv) {
 			return rv.String(), nil
 		}
 	}
 
-	return "", fmt.Errorf("no Node.js release found for major version %d", v.Major)
+	if v.Latest {
+		return "", fmt.Errorf("no Node.js releases found")
+	}
+	return "", fmt.Errorf("no Node.js release found matching %s", v.Raw)
 }
 
 // ListInstalledVersions returns all installed Node.js versions.

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"github.com/DriftrLabs/driftr/internal/config"
 	"github.com/DriftrLabs/driftr/internal/platform"
@@ -11,18 +12,93 @@ import (
 )
 
 // RequireInstalled verifies a version string parses correctly and the version is installed.
-// Returns the normalized version string and binary path, or an actionable error.
+// For partial versions (e.g. "24", "24.14") and "latest", it finds the best matching
+// installed version. Returns the normalized version string and binary path, or an actionable error.
 func RequireInstalled(versionSpec string) (string, string, error) {
 	v, err := version.Parse(versionSpec)
 	if err != nil {
 		return "", "", fmt.Errorf("invalid version: %w", err)
 	}
+
+	if v.Latest || v.IsPartial() {
+		return resolveInstalledPartial(v)
+	}
+
 	versionStr := v.String()
 	binPath, err := requireBinaryExists(versionStr, "")
 	if err != nil {
 		return "", "", err
 	}
 	return versionStr, binPath, nil
+}
+
+// resolveInstalledPartial finds the latest installed version matching a partial spec.
+func resolveInstalledPartial(v version.Version) (string, string, error) {
+	installed, err := listInstalledVersions()
+	if err != nil {
+		return "", "", err
+	}
+
+	var matches []version.Version
+	for _, verStr := range installed {
+		iv, err := version.Parse(verStr)
+		if err != nil {
+			continue
+		}
+		if v.Matches(iv) {
+			matches = append(matches, iv)
+		}
+	}
+
+	if len(matches) == 0 {
+		if v.Latest {
+			return "", "", fmt.Errorf("no Node.js versions installed. Run `driftr install node@<version>`")
+		}
+		return "", "", fmt.Errorf("no installed Node.js version matches %s. Run `driftr install node@%s`", v.Raw, v.Raw)
+	}
+
+	// Sort descending to pick the latest.
+	sort.Slice(matches, func(i, j int) bool {
+		if matches[i].Major != matches[j].Major {
+			return matches[i].Major > matches[j].Major
+		}
+		if matches[i].Minor != matches[j].Minor {
+			return matches[i].Minor > matches[j].Minor
+		}
+		return matches[i].Patch > matches[j].Patch
+	})
+
+	best := matches[0].String()
+	binPath, err := requireBinaryExists(best, "")
+	if err != nil {
+		return "", "", err
+	}
+	return best, binPath, nil
+}
+
+// listInstalledVersions returns all installed Node.js version strings.
+func listInstalledVersions() ([]string, error) {
+	toolsDir, err := platform.ToolsDir()
+	if err != nil {
+		return nil, err
+	}
+
+	nodeDir := toolsDir + "/node"
+	entries, err := os.ReadDir(nodeDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read node versions: %w", err)
+	}
+
+	var versions []string
+	for _, e := range entries {
+		if e.IsDir() {
+			versions = append(versions, e.Name())
+		}
+	}
+	return versions, nil
 }
 
 // requireBinaryExists checks that the node binary for the given version is installed.

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -8,10 +8,11 @@ import (
 
 // Version represents a parsed semantic version.
 type Version struct {
-	Major int
-	Minor int
-	Patch int
-	Raw   string
+	Major  int
+	Minor  int
+	Patch  int
+	Raw    string
+	Latest bool // true when input was "latest" or "node@latest"
 }
 
 // Parse parses a version string like "24", "24.0", or "24.0.1".
@@ -24,6 +25,10 @@ func Parse(s string) (Version, error) {
 
 	if s == "" {
 		return Version{}, fmt.Errorf("empty version string")
+	}
+
+	if s == "latest" {
+		return Version{Raw: raw, Latest: true}, nil
 	}
 
 	parts := strings.SplitN(s, ".", 3)
@@ -70,6 +75,31 @@ func (v Version) String() string {
 // MajorMinor returns "MAJOR.MINOR" format.
 func (v Version) MajorMinor() string {
 	return fmt.Sprintf("%d.%d", v.Major, v.Minor)
+}
+
+// Matches returns true if v (potentially partial) matches other (full version).
+// "24" matches any 24.x.x, "24.14" matches any 24.14.x, "24.14.1" is exact.
+// A Latest version matches everything.
+func (v Version) Matches(other Version) bool {
+	if v.Latest {
+		return true
+	}
+	if v.Major != other.Major {
+		return false
+	}
+	raw := strings.TrimPrefix(v.Raw, "node@")
+	raw = strings.TrimPrefix(raw, "v")
+	parts := strings.Split(raw, ".")
+	if len(parts) == 1 {
+		return true // major-only match
+	}
+	if v.Minor != other.Minor {
+		return false
+	}
+	if len(parts) == 2 {
+		return true // major.minor match
+	}
+	return v.Patch == other.Patch
 }
 
 // MatchesMajor returns true if the other version has the same major version.

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -69,6 +69,58 @@ func TestMajorMinor(t *testing.T) {
 	}
 }
 
+func TestParse_Latest(t *testing.T) {
+	tests := []string{"latest", "node@latest"}
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			v, err := Parse(input)
+			if err != nil {
+				t.Fatalf("Parse(%q) unexpected error: %v", input, err)
+			}
+			if !v.Latest {
+				t.Errorf("Parse(%q).Latest = false, want true", input)
+			}
+		})
+	}
+}
+
+func TestMatches(t *testing.T) {
+	tests := []struct {
+		pattern string
+		target  string
+		want    bool
+	}{
+		{"24", "24.14.1", true},
+		{"24", "24.0.0", true},
+		{"24", "22.14.0", false},
+		{"24.14", "24.14.1", true},
+		{"24.14", "24.14.0", true},
+		{"24.14", "24.13.0", false},
+		{"24.14", "22.14.0", false},
+		{"24.14.1", "24.14.1", true},
+		{"24.14.1", "24.14.0", false},
+		{"latest", "24.14.1", true},
+		{"latest", "22.0.0", true},
+		{"node@24", "24.14.1", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern+"_vs_"+tt.target, func(t *testing.T) {
+			p, err := Parse(tt.pattern)
+			if err != nil {
+				t.Fatalf("Parse(%q) error: %v", tt.pattern, err)
+			}
+			tgt, err := Parse(tt.target)
+			if err != nil {
+				t.Fatalf("Parse(%q) error: %v", tt.target, err)
+			}
+			if got := p.Matches(tgt); got != tt.want {
+				t.Errorf("Parse(%q).Matches(Parse(%q)) = %v, want %v", tt.pattern, tt.target, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMatchesMajor(t *testing.T) {
 	a, _ := Parse("24.0.0")
 	b, _ := Parse("24.1.3")


### PR DESCRIPTION
## Summary
- `driftr default node@24` and `driftr pin node@24` now resolve against installed versions instead of naively padding to `24.0.0`
- `node@24` resolves to the latest installed `24.x.x`
- `node@24.14` resolves to the latest installed `24.14.x`
- `node@latest` resolves to the newest installed version (or newest remote release for install)
- `resolveLatestVersion()` now uses `Matches()` for consistent major.minor matching

Closes #27