### PR TITLE
feat: add `driftr update` command for self-updating

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -48,6 +48,7 @@ func NewRootCmd() *cobra.Command {
 		newRunCmd(),
 		newShimCmd(),
 		newSetupCmd(),
+		newUpdateCmd(),
 	)
 
 	return root

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/DriftrLabs/driftr/internal/updater"
+	"github.com/spf13/cobra"
+)
+
+func newUpdateCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "update",
+		Short: "Update driftr to the latest version",
+		Long:  "Check for a newer version of driftr and replace the current binary.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			newVersion, err := updater.Update(Version, verbose)
+			if err != nil {
+				return fmt.Errorf("update failed: %w", err)
+			}
+
+			if newVersion == "" {
+				fmt.Printf("driftr v%s is already the latest version.\n", Version)
+			} else {
+				fmt.Printf("Updated successfully to driftr v%s!\n", newVersion)
+			}
+			return nil
+		},
+	}
+}

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -1,0 +1,297 @@
+package updater
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const (
+	repo       = "DriftrLabs/driftr"
+	apiBaseURL = "https://api.github.com/repos/" + repo
+)
+
+var httpClient = &http.Client{Timeout: 60 * time.Second}
+
+// githubRelease represents the relevant fields from the GitHub releases API.
+type githubRelease struct {
+	TagName string `json:"tag_name"`
+}
+
+// Update checks for a newer version and replaces the current binary.
+// Returns the new version string, or empty string if already up to date.
+func Update(currentVersion string, verbose bool) (string, error) {
+	fmt.Println("Checking for updates...")
+
+	latest, err := fetchLatestVersion()
+	if err != nil {
+		return "", fmt.Errorf("failed to check for updates: %w", err)
+	}
+
+	if verbose {
+		fmt.Printf("  Current: %s, Latest: %s\n", currentVersion, latest)
+	}
+
+	if latest == currentVersion {
+		return "", nil
+	}
+
+	fmt.Printf("Updating driftr v%s → v%s...\n", currentVersion, latest)
+
+	archiveName := fmt.Sprintf("driftr_%s_%s_%s.tar.gz", latest, runtime.GOOS, runtime.GOARCH)
+	baseURL := fmt.Sprintf("https://github.com/%s/releases/download/v%s", repo, latest)
+
+	tmpDir, err := os.MkdirTemp("", "driftr-update-*")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Download archive.
+	archivePath := filepath.Join(tmpDir, archiveName)
+	fmt.Printf("Downloading %s...\n", archiveName)
+	if err := downloadFile(baseURL+"/"+archiveName, archivePath); err != nil {
+		return "", fmt.Errorf("download failed: %w", err)
+	}
+
+	// Download and verify checksum.
+	checksumsPath := filepath.Join(tmpDir, "checksums.txt")
+	if err := downloadFile(baseURL+"/checksums.txt", checksumsPath); err != nil {
+		return "", fmt.Errorf("failed to download checksums: %w", err)
+	}
+
+	fmt.Println("Verifying checksum...")
+	if err := verifyChecksum(archivePath, checksumsPath); err != nil {
+		return "", err
+	}
+
+	// Extract the driftr binary from the archive.
+	newBinary := filepath.Join(tmpDir, "driftr")
+	if err := extractBinary(archivePath, newBinary); err != nil {
+		return "", fmt.Errorf("extraction failed: %w", err)
+	}
+
+	// Replace the current binary.
+	execPath, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine executable path: %w", err)
+	}
+	execPath, err = filepath.EvalSymlinks(execPath)
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve executable path: %w", err)
+	}
+
+	if err := replaceBinary(newBinary, execPath); err != nil {
+		return "", fmt.Errorf("failed to replace binary: %w", err)
+	}
+
+	return latest, nil
+}
+
+func fetchLatestVersion() (string, error) {
+	resp, err := httpClient.Get(apiBaseURL + "/releases/latest")
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
+	}
+
+	var release githubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return "", fmt.Errorf("failed to parse release info: %w", err)
+	}
+
+	return strings.TrimPrefix(release.TagName, "v"), nil
+}
+
+func downloadFile(url, dest string) error {
+	resp, err := httpClient.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP %d for %s", resp.StatusCode, url)
+	}
+
+	f, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if isTerminal(os.Stderr) {
+		pw := &progressWriter{dest: f, total: resp.ContentLength}
+		_, err = io.Copy(pw, resp.Body)
+		pw.finish()
+	} else {
+		_, err = io.Copy(f, resp.Body)
+	}
+	return err
+}
+
+func verifyChecksum(archivePath, checksumsPath string) error {
+	archiveName := filepath.Base(archivePath)
+
+	// Read checksums file.
+	data, err := os.ReadFile(checksumsPath)
+	if err != nil {
+		return fmt.Errorf("failed to read checksums: %w", err)
+	}
+
+	var expected string
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.Contains(line, archiveName) {
+			parts := strings.Fields(line)
+			if len(parts) >= 1 {
+				expected = parts[0]
+			}
+			break
+		}
+	}
+	if expected == "" {
+		return fmt.Errorf("no checksum found for %s", archiveName)
+	}
+
+	// Compute actual checksum.
+	f, err := os.Open(archivePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return err
+	}
+	actual := hex.EncodeToString(h.Sum(nil))
+
+	if actual != expected {
+		return fmt.Errorf("checksum mismatch: expected %s, got %s", expected, actual)
+	}
+	return nil
+}
+
+func extractBinary(archivePath, destPath string) error {
+	f, err := os.Open(archivePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return err
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		if filepath.Base(hdr.Name) == "driftr" && hdr.Typeflag == tar.TypeReg {
+			out, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(out, tr); err != nil {
+				out.Close()
+				return err
+			}
+			out.Close()
+			return nil
+		}
+	}
+	return fmt.Errorf("driftr binary not found in archive")
+}
+
+func replaceBinary(newPath, oldPath string) error {
+	// Atomic replace: rename new over old.
+	// On Unix this works even while the old binary is running.
+	if err := os.Rename(newPath, oldPath); err != nil {
+		// Cross-device rename fails — fall back to copy.
+		return copyFile(newPath, oldPath)
+	}
+	return nil
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, in)
+	return err
+}
+
+// isTerminal reports whether f is connected to a terminal.
+func isTerminal(f *os.File) bool {
+	fi, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+// progressWriter wraps an io.Writer to report download progress to stderr.
+type progressWriter struct {
+	dest      io.Writer
+	total     int64
+	written   int64
+	lastPrint time.Time
+}
+
+func (pw *progressWriter) Write(p []byte) (int, error) {
+	n, err := pw.dest.Write(p)
+	pw.written += int64(n)
+
+	if time.Since(pw.lastPrint) >= 100*time.Millisecond {
+		pw.printProgress()
+		pw.lastPrint = time.Now()
+	}
+
+	return n, err
+}
+
+func (pw *progressWriter) printProgress() {
+	downloadedMB := float64(pw.written) / (1024 * 1024)
+	if pw.total > 0 {
+		totalMB := float64(pw.total) / (1024 * 1024)
+		fmt.Fprintf(os.Stderr, "\r  Downloading: %.1f MB / %.1f MB", downloadedMB, totalMB)
+	} else {
+		fmt.Fprintf(os.Stderr, "\r  Downloading: %.1f MB", downloadedMB)
+	}
+}
+
+func (pw *progressWriter) finish() {
+	pw.printProgress()
+	fmt.Fprint(os.Stderr, "\n")
+}


### PR DESCRIPTION
## Summary
- Adds `driftr update` command that checks GitHub releases, downloads the latest version, verifies checksum, and replaces the binary in place
- Uses `os.Executable()` + `filepath.EvalSymlinks()` to find the real binary path
- Atomic replacement via `os.Rename`, with copy fallback for cross-device moves
- Progress reporting on TTY, suppressed on non-TTY
- Exits cleanly with "already the latest version" when up to date

Closes #26