### PR TITLE
refactor: generalize core from Node-specific to multi-tool

### DIFF
--- a/internal/cli/default.go
+++ b/internal/cli/default.go
@@ -11,11 +11,13 @@ import (
 func newDefaultCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "default <tool@version>",
-		Short: "Set the global default Node.js version",
-		Long:  "Set which Node.js version is used outside of pinned projects.\n\nExample:\n  driftr default node@24.0.0",
+		Short: "Set the global default version for a tool",
+		Long:  "Set which version is used outside of pinned projects.\n\nExamples:\n  driftr default node@24.0.0\n  driftr default node@24",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			versionStr, _, err := resolver.RequireInstalled(args[0])
+			tool, versionSpec := parseToolVersion(args[0])
+
+			versionStr, _, err := resolver.RequireToolInstalled(tool, versionSpec)
 			if err != nil {
 				return err
 			}
@@ -25,12 +27,12 @@ func newDefaultCmd() *cobra.Command {
 				return err
 			}
 
-			cfg.Default.Node = versionStr
+			cfg.Default.SetTool(tool, versionStr)
 			if err := config.SaveGlobal(cfg); err != nil {
 				return err
 			}
 
-			fmt.Printf("Set global default to Node.js %s\n", versionStr)
+			fmt.Printf("Set global default to %s %s\n", tool, versionStr)
 			return nil
 		},
 	}

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -10,11 +10,12 @@ import (
 func newInstallCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "install <tool@version>",
-		Short: "Install a Node.js version",
-		Long:  "Download and install a specific Node.js version.\n\nExamples:\n  driftr install node@24\n  driftr install node@22.14.0",
+		Short: "Install a tool version",
+		Long:  "Download and install a specific tool version.\n\nExamples:\n  driftr install node@24\n  driftr install node@22.14.0\n  driftr install node@latest",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			spec := args[0]
+			tool, _ := parseToolVersion(spec)
 
 			fmt.Printf("Installing %s...\n", spec)
 
@@ -23,7 +24,7 @@ func newInstallCmd() *cobra.Command {
 				return fmt.Errorf("installation failed: %w", err)
 			}
 
-			fmt.Printf("Installed Node.js %s\n", resolved)
+			fmt.Printf("Installed %s %s\n", tool, resolved)
 			return nil
 		},
 	}

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -10,18 +10,25 @@ import (
 
 func newListCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:     "list",
+		Use:     "list [tool]",
 		Aliases: []string{"ls"},
-		Short:   "List installed Node.js versions",
+		Short:   "List installed versions",
+		Long:    "List installed versions for a tool. Defaults to node.\n\nExamples:\n  driftr list\n  driftr list node",
+		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			versions, err := installer.ListInstalledVersions()
+			tool := "node"
+			if len(args) > 0 {
+				tool = args[0]
+			}
+
+			versions, err := installer.ListInstalledToolVersions(tool)
 			if err != nil {
 				return fmt.Errorf("failed to list versions: %w", err)
 			}
 
 			if len(versions) == 0 {
-				fmt.Println("No Node.js versions installed.")
-				fmt.Println("Run `driftr install node@<version>` to get started.")
+				fmt.Printf("No %s versions installed.\n", tool)
+				fmt.Printf("Run `driftr install %s@<version>` to get started.\n", tool)
 				return nil
 			}
 
@@ -30,16 +37,18 @@ func newListCmd() *cobra.Command {
 				return fmt.Errorf("failed to load global config: %w", err)
 			}
 
-			fmt.Println("Installed Node.js versions:")
+			defaultVer := cfg.Default.GetTool(tool)
+
+			fmt.Printf("Installed %s versions:\n", tool)
 			for _, v := range versions {
 				marker := "  "
-				if v == cfg.Default.Node {
+				if v == defaultVer {
 					marker = "* "
 				}
 				fmt.Printf("  %s%s\n", marker, v)
 			}
 
-			if cfg.Default.Node != "" {
+			if defaultVer != "" {
 				fmt.Printf("\n  * = global default\n")
 			}
 

--- a/internal/cli/parse.go
+++ b/internal/cli/parse.go
@@ -1,0 +1,12 @@
+package cli
+
+import "strings"
+
+// parseToolVersion splits "node@24.0.0" into ("node", "24.0.0").
+// If no "@" is present, defaults to tool "node".
+func parseToolVersion(spec string) (string, string) {
+	if i := strings.Index(spec, "@"); i >= 0 {
+		return spec[:i], spec[i+1:]
+	}
+	return "node", spec
+}

--- a/internal/cli/pin.go
+++ b/internal/cli/pin.go
@@ -26,8 +26,8 @@ func newPinCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "pin <tool@version>",
-		Short: "Pin a Node.js version to the current project",
-		Long: `Pin a Node.js version to the current project.
+		Short: "Pin a tool version to the current project",
+		Long: `Pin a tool version to the current project.
 
 The version is stored in .driftr.toml or package.json (driftr key).
 On first use, you'll be asked which format to use. Subsequent pins
@@ -38,7 +38,9 @@ Examples:
   driftr pin node@22.14.0 --migrate   # switch storage format`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			versionStr, _, err := resolver.RequireInstalled(args[0])
+			tool, versionSpec := parseToolVersion(args[0])
+
+			versionStr, _, err := resolver.RequireToolInstalled(tool, versionSpec)
 			if err != nil {
 				return err
 			}
@@ -51,7 +53,7 @@ Examples:
 			current := detectPinFormat(cwd)
 
 			if migrate {
-				return migratePin(cwd, versionStr, current)
+				return migratePin(cwd, tool, versionStr, current)
 			}
 
 			format := current
@@ -63,7 +65,7 @@ Examples:
 				}
 			}
 
-			return savePin(cwd, versionStr, format)
+			return savePin(cwd, tool, versionStr, format)
 		},
 	}
 
@@ -96,7 +98,7 @@ func promptPinFormat(cmd *cobra.Command) (pinFormat, error) {
 		return formatTOML, nil
 	}
 
-	fmt.Fprintln(cmd.ErrOrStderr(), "No existing project config found. How should the Node.js version be stored?")
+	fmt.Fprintln(cmd.ErrOrStderr(), "No existing project config found. How should the version be stored?")
 	fmt.Fprintln(cmd.ErrOrStderr(), "  1) .driftr.toml (recommended)")
 	fmt.Fprintln(cmd.ErrOrStderr(), "  2) package.json (driftr key)")
 	fmt.Fprint(cmd.ErrOrStderr(), "Choose [1/2]: ")
@@ -116,13 +118,13 @@ func promptPinFormat(cmd *cobra.Command) (pinFormat, error) {
 }
 
 // savePin writes the version in the given format.
-func savePin(dir, versionStr string, format pinFormat) error {
+func savePin(dir, tool, versionStr string, format pinFormat) error {
 	switch format {
 	case formatPackageJSON:
-		if err := config.SavePackageJSON(dir, versionStr); err != nil {
+		if err := config.SavePackageJSONTool(dir, tool, versionStr); err != nil {
 			return err
 		}
-		fmt.Printf("Pinned Node.js %s in %s/package.json\n", versionStr, dir)
+		fmt.Printf("Pinned %s %s in %s/package.json\n", tool, versionStr, dir)
 	default:
 		cfg, err := config.LoadProject(dir)
 		if err != nil {
@@ -131,40 +133,40 @@ func savePin(dir, versionStr string, format pinFormat) error {
 		if cfg == nil {
 			cfg = &config.ProjectConfig{}
 		}
-		cfg.Tools.Node = versionStr
+		cfg.Tools.SetTool(tool, versionStr)
 		if err := config.SaveProject(dir, cfg); err != nil {
 			return err
 		}
-		fmt.Printf("Pinned Node.js %s in %s/%s\n", versionStr, dir, config.ProjectConfigFile)
+		fmt.Printf("Pinned %s %s in %s/%s\n", tool, versionStr, dir, config.ProjectConfigFile)
 	}
 	return nil
 }
 
 // migratePin switches from the current format to the other one.
-func migratePin(dir, versionStr string, current pinFormat) error {
+func migratePin(dir, tool, versionStr string, current pinFormat) error {
 	switch current {
 	case formatTOML:
 		// Migrate TOML → package.json.
-		if err := config.SavePackageJSON(dir, versionStr); err != nil {
+		if err := config.SavePackageJSONTool(dir, tool, versionStr); err != nil {
 			return err
 		}
 		os.Remove(filepath.Join(dir, config.ProjectConfigFile))
-		fmt.Printf("Migrated Node.js %s from %s to package.json\n", versionStr, config.ProjectConfigFile)
+		fmt.Printf("Migrated %s %s from %s to package.json\n", tool, versionStr, config.ProjectConfigFile)
 
 	case formatPackageJSON:
 		// Migrate package.json → TOML.
 		cfg := &config.ProjectConfig{}
-		cfg.Tools.Node = versionStr
+		cfg.Tools.SetTool(tool, versionStr)
 		if err := config.SaveProject(dir, cfg); err != nil {
 			return err
 		}
 		if err := config.RemoveDriftrFromPackageJSON(dir); err != nil {
 			return err
 		}
-		fmt.Printf("Migrated Node.js %s from package.json to %s\n", versionStr, config.ProjectConfigFile)
+		fmt.Printf("Migrated %s %s from package.json to %s\n", tool, versionStr, config.ProjectConfigFile)
 
 	case formatNone:
-		return fmt.Errorf("no existing config to migrate. Run `driftr pin node@<version>` first")
+		return fmt.Errorf("no existing config to migrate. Run `driftr pin %s@<version>` first", tool)
 	}
 	return nil
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -31,7 +31,7 @@ func NewRootCmd() *cobra.Command {
 	root := &cobra.Command{
 		Use:           "driftr",
 		Short:         "Fast, cross-platform JavaScript toolchain manager",
-		Long:          "Driftr manages Node.js versions with automatic per-project resolution and shim-based execution.",
+		Long:          "Driftr manages tool versions with automatic per-project resolution and shim-based execution.",
 		Version:       fmt.Sprintf("%s (commit: %s, built: %s)", Version, Commit, Date),
 		SilenceUsage:  true,
 		SilenceErrors: true,

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -14,7 +14,7 @@ func newRunCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                "run [flags] -- <command> [args...]",
 		Short:              "Run a command under a specific Node.js version",
-		Long:               "Execute a command using an explicitly specified Node.js version without changing defaults.\n\nExample:\n  driftr run --node 24.0.0 -- npm test",
+		Long:               "Execute a command using an explicitly specified Node.js version without changing defaults.\n\nExamples:\n  driftr run --node 24.0.0 -- npm test\n  driftr run --node 24 -- node -v",
 		DisableFlagParsing: false,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {

--- a/internal/cli/which.go
+++ b/internal/cli/which.go
@@ -17,7 +17,7 @@ func newWhichCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			tool := args[0]
 
-			res, err := resolver.ResolveNodeVerbose("", verbose)
+			res, err := resolver.ResolveTool("node", "", verbose)
 			if err != nil {
 				return err
 			}

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -16,7 +16,33 @@ type GlobalConfig struct {
 
 // DefaultConfig holds the default tool versions.
 type DefaultConfig struct {
-	Node string `toml:"node"`
+	Node  string            `toml:"node"`            // backwards compat: [default] node = "..."
+	Tools map[string]string `toml:"tools,omitempty"` // [default.tools] node = "..."
+}
+
+// GetTool returns the default version for a tool, checking both the map and legacy field.
+func (d *DefaultConfig) GetTool(tool string) string {
+	if d.Tools != nil {
+		if v, ok := d.Tools[tool]; ok {
+			return v
+		}
+	}
+	if tool == "node" {
+		return d.Node
+	}
+	return ""
+}
+
+// SetTool sets the default version for a tool.
+func (d *DefaultConfig) SetTool(tool, version string) {
+	if d.Tools == nil {
+		d.Tools = make(map[string]string)
+	}
+	d.Tools[tool] = version
+	// Keep legacy field in sync for backwards compat.
+	if tool == "node" {
+		d.Node = version
+	}
 }
 
 // LoadGlobal reads the global configuration file.

--- a/internal/config/packagejson.go
+++ b/internal/config/packagejson.go
@@ -14,12 +14,28 @@ type PackageJSON struct {
 }
 
 // DriftrConfig holds the Driftr tool pinning from package.json.
+// Supports both the legacy `"node"` field and additional tools.
 type DriftrConfig struct {
-	Node string `json:"node"`
+	Node string `json:"node,omitempty"`
 }
 
-// LoadPackageJSON reads the driftr.node version from package.json in the given directory.
-// Returns (nil, nil) if the file doesn't exist or has no driftr.node field.
+// GetTool returns the pinned version for a tool from package.json.
+func (dc *DriftrConfig) GetTool(tool string) string {
+	if tool == "node" {
+		return dc.Node
+	}
+	return ""
+}
+
+// SetTool sets the pinned version for a tool.
+func (dc *DriftrConfig) SetTool(tool, version string) {
+	if tool == "node" {
+		dc.Node = version
+	}
+}
+
+// LoadPackageJSON reads driftr tool versions from package.json in the given directory.
+// Returns (nil, nil) if the file doesn't exist or has no driftr key with tool versions.
 func LoadPackageJSON(dir string) (*PackageJSON, error) {
 	path := filepath.Join(dir, "package.json")
 
@@ -36,6 +52,7 @@ func LoadPackageJSON(dir string) (*PackageJSON, error) {
 		return nil, fmt.Errorf("failed to parse %s: %w", path, err)
 	}
 
+	// Return nil if no tool versions are configured.
 	if pkg.Driftr.Node == "" {
 		return nil, nil
 	}
@@ -43,9 +60,14 @@ func LoadPackageJSON(dir string) (*PackageJSON, error) {
 	return &pkg, nil
 }
 
-// SavePackageJSON writes the driftr.node version into an existing package.json.
+// SavePackageJSON writes a tool version into the driftr key in package.json.
 // Returns an error if package.json does not exist in the directory.
-func SavePackageJSON(dir string, nodeVersion string) error {
+func SavePackageJSON(dir string, version string) error {
+	return SavePackageJSONTool(dir, "node", version)
+}
+
+// SavePackageJSONTool writes a specific tool version into the driftr key in package.json.
+func SavePackageJSONTool(dir, tool, version string) error {
 	path := filepath.Join(dir, "package.json")
 
 	data, err := os.ReadFile(path)
@@ -56,7 +78,12 @@ func SavePackageJSON(dir string, nodeVersion string) error {
 		return fmt.Errorf("failed to read %s: %w", path, err)
 	}
 
-	driftrValue, err := json.Marshal(DriftrConfig{Node: nodeVersion})
+	// Load existing driftr config to preserve other tools.
+	var existing PackageJSON
+	_ = json.Unmarshal(data, &existing)
+	existing.Driftr.SetTool(tool, version)
+
+	driftrValue, err := json.Marshal(existing.Driftr)
 	if err != nil {
 		return err
 	}

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -16,8 +16,34 @@ type ProjectConfig struct {
 }
 
 // ToolsConfig holds pinned tool versions for a project.
+// Supports both the legacy `node = "..."` field and a generic map.
 type ToolsConfig struct {
-	Node string `toml:"node"`
+	Node    string            `toml:"node,omitempty"`    // backwards compat
+	Entries map[string]string `toml:"-"`                 // populated after load
+}
+
+// GetTool returns the pinned version for a tool.
+func (tc *ToolsConfig) GetTool(tool string) string {
+	if tc.Entries != nil {
+		if v, ok := tc.Entries[tool]; ok {
+			return v
+		}
+	}
+	if tool == "node" {
+		return tc.Node
+	}
+	return ""
+}
+
+// SetTool sets the pinned version for a tool.
+func (tc *ToolsConfig) SetTool(tool, version string) {
+	if tc.Entries == nil {
+		tc.Entries = make(map[string]string)
+	}
+	tc.Entries[tool] = version
+	if tool == "node" {
+		tc.Node = version
+	}
 }
 
 // LoadProject reads the project config from the given directory.

--- a/internal/installer/node.go
+++ b/internal/installer/node.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
@@ -174,18 +175,23 @@ func resolveLatestVersion(v version.Version) (string, error) {
 
 // ListInstalledVersions returns all installed Node.js versions.
 func ListInstalledVersions() ([]string, error) {
+	return ListInstalledToolVersions("node")
+}
+
+// ListInstalledToolVersions returns all installed versions for a given tool.
+func ListInstalledToolVersions(tool string) ([]string, error) {
 	toolsDir, err := platform.ToolsDir()
 	if err != nil {
 		return nil, err
 	}
 
-	nodeDir := toolsDir + "/node"
-	entries, err := os.ReadDir(nodeDir)
+	toolDir := filepath.Join(toolsDir, tool)
+	entries, err := os.ReadDir(toolDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to read node versions: %w", err)
+		return nil, fmt.Errorf("failed to read %s versions: %w", tool, err)
 	}
 
 	var versions []string

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -34,40 +34,33 @@ func ToolsDir() (string, error) {
 	return filepath.Join(home, "tools"), nil
 }
 
-// NodeVersionDir returns the directory for a specific Node version.
-func NodeVersionDir(version string) (string, error) {
+// ToolVersionDir returns the directory for a specific tool and version.
+func ToolVersionDir(tool, version string) (string, error) {
 	tools, err := ToolsDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(tools, "node", version), nil
+	return filepath.Join(tools, tool, version), nil
+}
+
+// NodeVersionDir returns the directory for a specific Node version.
+func NodeVersionDir(version string) (string, error) {
+	return ToolVersionDir("node", version)
 }
 
 // NodeBinary returns the path to the node binary for a given version.
 func NodeBinary(version string) (string, error) {
-	dir, err := NodeVersionDir(version)
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, "bin", "node"), nil
+	return ToolBinary("node", version)
 }
 
 // NpmBinary returns the path to the npm binary for a given version.
 func NpmBinary(version string) (string, error) {
-	dir, err := NodeVersionDir(version)
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, "bin", "npm"), nil
+	return ToolBinary("npm", version)
 }
 
 // NpxBinary returns the path to the npx binary for a given version.
 func NpxBinary(version string) (string, error) {
-	dir, err := NodeVersionDir(version)
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, "bin", "npx"), nil
+	return ToolBinary("npx", version)
 }
 
 // CacheDir returns the cache directory (~/.driftr/cache).
@@ -90,6 +83,11 @@ func GlobalConfigPath() (string, error) {
 
 // EnsureDirs creates all required Driftr directories.
 func EnsureDirs() error {
+	return EnsureToolDirs("node")
+}
+
+// EnsureToolDirs creates all required Driftr directories including tool-specific ones.
+func EnsureToolDirs(tools ...string) error {
 	home, err := DriftrHome()
 	if err != nil {
 		return err
@@ -97,9 +95,12 @@ func EnsureDirs() error {
 
 	dirs := []string{
 		filepath.Join(home, "bin"),
-		filepath.Join(home, "tools", "node"),
 		filepath.Join(home, "config"),
 		filepath.Join(home, "cache"),
+	}
+
+	for _, tool := range tools {
+		dirs = append(dirs, filepath.Join(home, "tools", tool))
 	}
 
 	for _, d := range dirs {
@@ -137,18 +138,29 @@ func OS() string {
 	}
 }
 
-// ToolBinary returns the binary path for a given tool and Node.js version.
+// toolBinaryMap maps tool names to their parent tool (for tools bundled with node)
+// and binary name within the version directory.
+var toolBinaryMap = map[string]struct {
+	parent string // which tool's version dir contains this binary
+	binary string // binary name under bin/
+}{
+	"node": {parent: "node", binary: "node"},
+	"npm":  {parent: "node", binary: "npm"},
+	"npx":  {parent: "node", binary: "npx"},
+}
+
+// ToolBinary returns the binary path for a given tool and version.
+// For bundled tools (npm, npx), the version refers to the parent tool (node).
 func ToolBinary(tool, version string) (string, error) {
-	switch tool {
-	case "node":
-		return NodeBinary(version)
-	case "npm":
-		return NpmBinary(version)
-	case "npx":
-		return NpxBinary(version)
-	default:
+	entry, ok := toolBinaryMap[tool]
+	if !ok {
 		return "", fmt.Errorf("unknown tool: %s", tool)
 	}
+	dir, err := ToolVersionDir(entry.parent, version)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "bin", entry.binary), nil
 }
 
 // ArchiveExt returns the archive extension for the current platform.

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -15,17 +15,22 @@ import (
 // For partial versions (e.g. "24", "24.14") and "latest", it finds the best matching
 // installed version. Returns the normalized version string and binary path, or an actionable error.
 func RequireInstalled(versionSpec string) (string, string, error) {
+	return RequireToolInstalled("node", versionSpec)
+}
+
+// RequireToolInstalled verifies a tool version is installed, with partial version resolution.
+func RequireToolInstalled(tool, versionSpec string) (string, string, error) {
 	v, err := version.Parse(versionSpec)
 	if err != nil {
 		return "", "", fmt.Errorf("invalid version: %w", err)
 	}
 
 	if v.Latest || v.IsPartial() {
-		return resolveInstalledPartial(v)
+		return resolveInstalledPartial(tool, v)
 	}
 
 	versionStr := v.String()
-	binPath, err := requireBinaryExists(versionStr, "")
+	binPath, err := requireToolBinaryExists(tool, versionStr, "")
 	if err != nil {
 		return "", "", err
 	}
@@ -33,8 +38,8 @@ func RequireInstalled(versionSpec string) (string, string, error) {
 }
 
 // resolveInstalledPartial finds the latest installed version matching a partial spec.
-func resolveInstalledPartial(v version.Version) (string, string, error) {
-	installed, err := listInstalledVersions()
+func resolveInstalledPartial(tool string, v version.Version) (string, string, error) {
+	installed, err := ListToolVersions(tool)
 	if err != nil {
 		return "", "", err
 	}
@@ -52,9 +57,9 @@ func resolveInstalledPartial(v version.Version) (string, string, error) {
 
 	if len(matches) == 0 {
 		if v.Latest {
-			return "", "", fmt.Errorf("no Node.js versions installed. Run `driftr install node@<version>`")
+			return "", "", fmt.Errorf("no %s versions installed. Run `driftr install %s@<version>`", tool, tool)
 		}
-		return "", "", fmt.Errorf("no installed Node.js version matches %s. Run `driftr install node@%s`", v.Raw, v.Raw)
+		return "", "", fmt.Errorf("no installed %s version matches %s. Run `driftr install %s@%s`", tool, v.Raw, tool, v.Raw)
 	}
 
 	// Sort descending to pick the latest.
@@ -69,27 +74,27 @@ func resolveInstalledPartial(v version.Version) (string, string, error) {
 	})
 
 	best := matches[0].String()
-	binPath, err := requireBinaryExists(best, "")
+	binPath, err := requireToolBinaryExists(tool, best, "")
 	if err != nil {
 		return "", "", err
 	}
 	return best, binPath, nil
 }
 
-// listInstalledVersions returns all installed Node.js version strings.
-func listInstalledVersions() ([]string, error) {
+// ListToolVersions returns all installed version strings for a tool.
+func ListToolVersions(tool string) ([]string, error) {
 	toolsDir, err := platform.ToolsDir()
 	if err != nil {
 		return nil, err
 	}
 
-	nodeDir := toolsDir + "/node"
-	entries, err := os.ReadDir(nodeDir)
+	toolDir := filepath.Join(toolsDir, tool)
+	entries, err := os.ReadDir(toolDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to read node versions: %w", err)
+		return nil, fmt.Errorf("failed to read %s versions: %w", tool, err)
 	}
 
 	var versions []string
@@ -101,18 +106,17 @@ func listInstalledVersions() ([]string, error) {
 	return versions, nil
 }
 
-// requireBinaryExists checks that the node binary for the given version is installed.
-// The context string (e.g. "pinned in /path") is included in the error message if non-empty.
-func requireBinaryExists(ver, context string) (string, error) {
-	binPath, err := platform.NodeBinary(ver)
+// requireToolBinaryExists checks that the binary for the given tool and version is installed.
+func requireToolBinaryExists(tool, ver, context string) (string, error) {
+	binPath, err := platform.ToolBinary(tool, ver)
 	if err != nil {
 		return "", err
 	}
 	if _, err := os.Stat(binPath); os.IsNotExist(err) {
 		if context != "" {
-			return "", fmt.Errorf("Node %s (%s) is not installed. Run `driftr install node@%s`", ver, context, ver)
+			return "", fmt.Errorf("%s %s (%s) is not installed. Run `driftr install %s@%s`", tool, ver, context, tool, ver)
 		}
-		return "", fmt.Errorf("Node %s is not installed. Run `driftr install node@%s`", ver, ver)
+		return "", fmt.Errorf("%s %s is not installed. Run `driftr install %s@%s`", tool, ver, tool, ver)
 	}
 	return binPath, nil
 }
@@ -123,7 +127,7 @@ type Source int
 const (
 	SourceExplicit    Source = iota
 	SourceProject            // .driftr.toml
-	SourcePackageJSON        // package.json driftr.node
+	SourcePackageJSON        // package.json driftr key
 	SourceGlobal
 )
 
@@ -152,22 +156,27 @@ type Resolution struct {
 }
 
 // ResolveNode determines which Node.js version to use.
-// Resolution order: explicit > project config > global default.
 func ResolveNode(explicit string) (*Resolution, error) {
-	return ResolveNodeVerbose(explicit, false)
+	return ResolveTool("node", explicit, false)
 }
 
 // ResolveNodeVerbose determines which Node.js version to use, with optional tracing.
 func ResolveNodeVerbose(explicit string, verbose bool) (*Resolution, error) {
+	return ResolveTool("node", explicit, verbose)
+}
+
+// ResolveTool determines which version of a tool to use.
+// Resolution order: explicit > project config > global default.
+func ResolveTool(tool, explicit string, verbose bool) (*Resolution, error) {
 	if verbose {
-		fmt.Println("  [resolve] Starting Node.js version resolution")
+		fmt.Printf("  [resolve] Starting %s version resolution\n", tool)
 	}
 
 	if explicit != "" {
 		if verbose {
 			fmt.Printf("  [resolve] Step 1: Explicit override provided: %s\n", explicit)
 		}
-		return resolveExplicit(explicit)
+		return resolveExplicit(tool, explicit)
 	}
 	if verbose {
 		fmt.Println("  [resolve] Step 1: No explicit override")
@@ -182,7 +191,7 @@ func ResolveNodeVerbose(explicit string, verbose bool) (*Resolution, error) {
 		fmt.Printf("  [resolve] Step 2: Searching for project config from %s\n", cwd)
 	}
 
-	res, err := resolveFromProject(cwd, verbose)
+	res, err := resolveFromProject(tool, cwd, verbose)
 	if err != nil {
 		return nil, err
 	}
@@ -197,7 +206,7 @@ func ResolveNodeVerbose(explicit string, verbose bool) (*Resolution, error) {
 		fmt.Println("  [resolve] Step 3: No project config found, checking global default")
 	}
 
-	res, err = resolveFromGlobal()
+	res, err = resolveFromGlobal(tool)
 	if err != nil {
 		if verbose {
 			fmt.Printf("  [resolve] Global default failed: %v\n", err)
@@ -212,13 +221,13 @@ func ResolveNodeVerbose(explicit string, verbose bool) (*Resolution, error) {
 	return res, nil
 }
 
-func resolveExplicit(ver string) (*Resolution, error) {
-	binPath, err := requireBinaryExists(ver, "")
+func resolveExplicit(tool, ver string) (*Resolution, error) {
+	binPath, err := requireToolBinaryExists(tool, ver, "")
 	if err != nil {
 		return nil, err
 	}
 	return &Resolution{
-		Tool:       "node",
+		Tool:       tool,
 		Version:    ver,
 		BinaryPath: binPath,
 		Source:     SourceExplicit,
@@ -227,14 +236,12 @@ func resolveExplicit(ver string) (*Resolution, error) {
 
 const maxResolveDepth = 20
 
-func resolveFromProject(dir string, verbose bool) (*Resolution, error) {
+func resolveFromProject(tool, dir string, verbose bool) (*Resolution, error) {
 	absDir, err := filepath.Abs(dir)
 	if err != nil {
 		return nil, err
 	}
 
-	// Walk up directories looking for .driftr.toml or package.json (volta),
-	// checking both in each directory before moving to the parent.
 	current := absDir
 	depth := 0
 	for {
@@ -254,11 +261,13 @@ func resolveFromProject(dir string, verbose bool) (*Resolution, error) {
 		if err != nil {
 			return nil, err
 		}
-		if cfg != nil && cfg.Tools.Node != "" {
-			return resolveProjectVersion(cfg.Tools.Node, current, SourceProject)
+		if cfg != nil {
+			if ver := cfg.Tools.GetTool(tool); ver != "" {
+				return resolveProjectVersion(tool, ver, current, SourceProject)
+			}
 		}
 
-		// Check package.json volta.node.
+		// Check package.json driftr key.
 		pkgPath := filepath.Join(current, "package.json")
 		if verbose {
 			fmt.Printf("  [resolve]   Checking: %s (driftr)\n", pkgPath)
@@ -269,7 +278,9 @@ func resolveFromProject(dir string, verbose bool) (*Resolution, error) {
 			return nil, err
 		}
 		if pkg != nil {
-			return resolveProjectVersion(pkg.Driftr.Node, current, SourcePackageJSON)
+			if ver := pkg.Driftr.GetTool(tool); ver != "" {
+				return resolveProjectVersion(tool, ver, current, SourcePackageJSON)
+			}
 		}
 
 		depth++
@@ -283,13 +294,13 @@ func resolveFromProject(dir string, verbose bool) (*Resolution, error) {
 	return nil, nil
 }
 
-func resolveProjectVersion(ver, dir string, source Source) (*Resolution, error) {
-	binPath, err := requireBinaryExists(ver, "pinned in "+dir)
+func resolveProjectVersion(tool, ver, dir string, source Source) (*Resolution, error) {
+	binPath, err := requireToolBinaryExists(tool, ver, "pinned in "+dir)
 	if err != nil {
 		return nil, err
 	}
 	return &Resolution{
-		Tool:       "node",
+		Tool:       tool,
 		Version:    ver,
 		BinaryPath: binPath,
 		Source:     source,
@@ -297,23 +308,23 @@ func resolveProjectVersion(ver, dir string, source Source) (*Resolution, error) 
 	}, nil
 }
 
-func resolveFromGlobal() (*Resolution, error) {
+func resolveFromGlobal(tool string) (*Resolution, error) {
 	cfg, err := config.LoadGlobal()
 	if err != nil {
 		return nil, err
 	}
 
-	if cfg.Default.Node == "" {
-		return nil, fmt.Errorf("no Node.js version configured. Run `driftr install node@<version>` and `driftr default node@<version>`")
+	ver := cfg.Default.GetTool(tool)
+	if ver == "" {
+		return nil, fmt.Errorf("no %s version configured. Run `driftr install %s@<version>` and `driftr default %s@<version>`", tool, tool, tool)
 	}
 
-	ver := cfg.Default.Node
-	binPath, err := requireBinaryExists(ver, "global default")
+	binPath, err := requireToolBinaryExists(tool, ver, "global default")
 	if err != nil {
 		return nil, err
 	}
 	return &Resolution{
-		Tool:       "node",
+		Tool:       tool,
 		Version:    ver,
 		BinaryPath: binPath,
 		Source:     SourceGlobal,

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,11 +15,19 @@ type Version struct {
 	Latest bool // true when input was "latest" or "node@latest"
 }
 
+// stripToolPrefix removes an optional "tool@" prefix (e.g. "node@24" → "24").
+func stripToolPrefix(s string) string {
+	if i := strings.Index(s, "@"); i >= 0 {
+		return s[i+1:]
+	}
+	return s
+}
+
 // Parse parses a version string like "24", "24.0", or "24.0.1".
-// Supports optional "v" prefix and "node@" prefix.
+// Supports optional "v" prefix and "tool@" prefix (e.g. "node@24").
 func Parse(s string) (Version, error) {
 	raw := s
-	s = strings.TrimPrefix(s, "node@")
+	s = stripToolPrefix(s)
 	s = strings.TrimPrefix(s, "v")
 	s = strings.TrimSpace(s)
 
@@ -61,7 +69,7 @@ func Parse(s string) (Version, error) {
 
 // IsPartial returns true if the version was specified without all three components.
 func (v Version) IsPartial() bool {
-	raw := strings.TrimPrefix(v.Raw, "node@")
+	raw := stripToolPrefix(v.Raw)
 	raw = strings.TrimPrefix(raw, "v")
 	parts := strings.Split(raw, ".")
 	return len(parts) < 3
@@ -87,7 +95,7 @@ func (v Version) Matches(other Version) bool {
 	if v.Major != other.Major {
 		return false
 	}
-	raw := strings.TrimPrefix(v.Raw, "node@")
+	raw := stripToolPrefix(v.Raw)
 	raw = strings.TrimPrefix(raw, "v")
 	parts := strings.Split(raw, ".")
 	if len(parts) == 1 {

--- a/test.sh
+++ b/test.sh
@@ -44,7 +44,7 @@ echo
 echo -e "${BLUE}[1] Basic CLI${NC}"
 check "driftr --help works" driftr --help
 check_output "help shows available commands" "Available Commands" driftr --help
-check_output "list shows no versions" "No Node.js versions installed" driftr list
+check_output "list shows no versions" "No node versions installed" driftr list
 echo
 
 # ── 2. Setup ──────────────────────────────────


### PR DESCRIPTION
## Summary
- Generalizes every layer (config, platform, resolver, installer, CLI, version) to support arbitrary tool names
- Maintains full backwards compatibility — existing `driftr install node@24` workflows and config files work unchanged
- Adds `GetTool()`/`SetTool()` methods to all config structs
- Replaces hardcoded `ToolBinary()` switch with data-driven `toolBinaryMap`
- Adds `ResolveTool()`, `RequireToolInstalled()`, `ListToolVersions()` as generic resolver APIs
- New `parseToolVersion()` CLI helper splits `tool@version` specs
- `version.Parse()` now strips any `tool@` prefix generically

Closes #19