### PR TITLE
feat: add npm registry client for package manager downloads

### DIFF
--- a/internal/installer/registry.go
+++ b/internal/installer/registry.go
@@ -1,0 +1,254 @@
+package installer
+
+import (
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/DriftrLabs/driftr/internal/platform"
+	"github.com/DriftrLabs/driftr/internal/version"
+)
+
+const registryBaseURL = "https://registry.npmjs.org"
+
+// registryPackage represents the top-level npm registry response for a package.
+type registryPackage struct {
+	Name     string                       `json:"name"`
+	DistTags map[string]string            `json:"dist-tags"`
+	Versions map[string]registryVersion   `json:"versions"`
+}
+
+// registryVersion represents a single version from the npm registry.
+type registryVersion struct {
+	Name    string            `json:"name"`
+	Version string            `json:"version"`
+	Dist    registryDist      `json:"dist"`
+	Bin     map[string]string `json:"bin,omitempty"`
+}
+
+// registryDist holds the distribution metadata for an npm package version.
+type registryDist struct {
+	Tarball   string `json:"tarball"`
+	Integrity string `json:"integrity"` // SRI format: "sha512-<base64>"
+	Shasum    string `json:"shasum"`    // sha1 hex (fallback)
+}
+
+// FetchRegistryVersion fetches metadata for a specific package version from the npm registry.
+func FetchRegistryVersion(pkg, ver string) (*registryVersion, error) {
+	url := fmt.Sprintf("%s/%s/%s", registryBaseURL, pkg, ver)
+	resp, err := httpClient.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch %s@%s from registry: %w", pkg, ver, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 404 {
+		return nil, fmt.Errorf("%s@%s not found in npm registry", pkg, ver)
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("npm registry returned status %d for %s@%s", resp.StatusCode, pkg, ver)
+	}
+
+	var rv registryVersion
+	if err := json.NewDecoder(resp.Body).Decode(&rv); err != nil {
+		return nil, fmt.Errorf("failed to parse registry response for %s@%s: %w", pkg, ver, err)
+	}
+	return &rv, nil
+}
+
+// ResolveRegistryLatest finds the latest version of an npm package matching a partial version spec.
+// For "latest" or when no constraint is given, returns the dist-tag "latest".
+func ResolveRegistryLatest(pkg string, v version.Version) (string, error) {
+	url := fmt.Sprintf("%s/%s", registryBaseURL, pkg)
+	resp, err := httpClient.Get(url)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch %s from registry: %w", pkg, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("npm registry returned status %d for %s", resp.StatusCode, pkg)
+	}
+
+	var rp registryPackage
+	if err := json.NewDecoder(resp.Body).Decode(&rp); err != nil {
+		return "", fmt.Errorf("failed to parse registry response for %s: %w", pkg, err)
+	}
+
+	// For "latest", use the dist-tag.
+	if v.Latest {
+		latest, ok := rp.DistTags["latest"]
+		if !ok {
+			return "", fmt.Errorf("no 'latest' dist-tag for %s", pkg)
+		}
+		return latest, nil
+	}
+
+	// Find the highest version matching the partial spec.
+	// Collect all matching versions, then pick the highest.
+	var best *version.Version
+	for verStr := range rp.Versions {
+		rv, err := version.Parse(verStr)
+		if err != nil {
+			continue
+		}
+		if !v.Matches(rv) {
+			continue
+		}
+		if best == nil || versionGreater(rv, *best) {
+			rv := rv // copy
+			best = &rv
+		}
+	}
+
+	if best == nil {
+		return "", fmt.Errorf("no %s version found matching %s", pkg, v.Raw)
+	}
+	return best.String(), nil
+}
+
+// versionGreater returns true if a > b in semver ordering.
+func versionGreater(a, b version.Version) bool {
+	if a.Major != b.Major {
+		return a.Major > b.Major
+	}
+	if a.Minor != b.Minor {
+		return a.Minor > b.Minor
+	}
+	return a.Patch > b.Patch
+}
+
+// DownloadRegistryPackage downloads an npm package tarball to the cache directory.
+// Returns the path to the downloaded file and the registry version metadata.
+func DownloadRegistryPackage(pkg, ver string, verbose bool) (string, *registryVersion, error) {
+	rv, err := FetchRegistryVersion(pkg, ver)
+	if err != nil {
+		return "", nil, err
+	}
+
+	cacheDir, err := platform.CacheDir()
+	if err != nil {
+		return "", nil, err
+	}
+
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return "", nil, fmt.Errorf("failed to create cache dir: %w", err)
+	}
+
+	filename := fmt.Sprintf("%s-%s.tgz", pkg, ver)
+	destPath := filepath.Join(cacheDir, filename)
+
+	// Skip download if already cached.
+	if info, err := os.Stat(destPath); err == nil && info.Size() > 0 {
+		if verbose {
+			fmt.Printf("  Using cached archive: %s\n", destPath)
+		}
+		return destPath, rv, nil
+	}
+
+	tarballURL := rv.Dist.Tarball
+	if verbose {
+		fmt.Printf("  Downloading: %s\n", tarballURL)
+	}
+
+	resp, err := httpClient.Get(tarballURL)
+	if err != nil {
+		return "", nil, fmt.Errorf("download failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return "", nil, fmt.Errorf("download failed with status %d", resp.StatusCode)
+	}
+
+	tmpFile, err := os.CreateTemp(cacheDir, "driftr-registry-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create temp file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+
+	if isTerminal(os.Stderr) {
+		pw := &progressWriter{dest: tmpFile, total: resp.ContentLength}
+		_, err = io.Copy(pw, resp.Body)
+		pw.finish()
+	} else {
+		_, err = io.Copy(tmpFile, resp.Body)
+	}
+	tmpFile.Close()
+	if err != nil {
+		os.Remove(tmpPath)
+		return "", nil, fmt.Errorf("download interrupted: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, destPath); err != nil {
+		os.Remove(tmpPath)
+		return "", nil, fmt.Errorf("failed to save archive: %w", err)
+	}
+
+	return destPath, rv, nil
+}
+
+// VerifyIntegrity verifies a file against an SRI integrity string (e.g. "sha512-<base64>").
+func VerifyIntegrity(filePath, integrity string) error {
+	algo, expectedHash, err := parseSRI(integrity)
+	if err != nil {
+		return err
+	}
+
+	if algo != "sha512" {
+		return fmt.Errorf("unsupported integrity algorithm: %s (expected sha512)", algo)
+	}
+
+	f, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to open file for integrity check: %w", err)
+	}
+	defer f.Close()
+
+	h := sha512.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return fmt.Errorf("failed to compute hash: %w", err)
+	}
+
+	actual := h.Sum(nil)
+	if !equalBytes(actual, expectedHash) {
+		return fmt.Errorf("integrity mismatch: expected sha512-%s, got sha512-%s",
+			base64.StdEncoding.EncodeToString(expectedHash),
+			base64.StdEncoding.EncodeToString(actual))
+	}
+
+	return nil
+}
+
+// parseSRI parses an SRI integrity string like "sha512-<base64>" into algorithm and raw hash bytes.
+func parseSRI(sri string) (string, []byte, error) {
+	parts := strings.SplitN(sri, "-", 2)
+	if len(parts) != 2 {
+		return "", nil, fmt.Errorf("invalid SRI format: %q", sri)
+	}
+
+	algo := parts[0]
+	hashBytes, err := base64.StdEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", nil, fmt.Errorf("invalid base64 in SRI: %w", err)
+	}
+
+	return algo, hashBytes, nil
+}
+
+func equalBytes(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/installer/registry_extract.go
+++ b/internal/installer/registry_extract.go
@@ -1,0 +1,81 @@
+package installer
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ExtractRegistryPackage extracts an npm registry tarball to the destination directory.
+// npm tarballs contain a top-level "package/" prefix which is stripped during extraction.
+func ExtractRegistryPackage(archivePath, destDir string) error {
+	f, err := os.Open(archivePath)
+	if err != nil {
+		return fmt.Errorf("failed to open archive: %w", err)
+	}
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return fmt.Errorf("failed to create gzip reader: %w", err)
+	}
+	defer gz.Close()
+
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create destination dir: %w", err)
+	}
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("failed to read tar entry: %w", err)
+		}
+
+		// Strip the "package/" prefix that all npm tarballs use.
+		name := hdr.Name
+		if i := strings.Index(name, "/"); i >= 0 {
+			name = name[i+1:]
+		}
+		if name == "" {
+			continue
+		}
+
+		// Sanitize: reject paths that escape the destination directory.
+		target := filepath.Join(destDir, name)
+		if !strings.HasPrefix(filepath.Clean(target), filepath.Clean(destDir)+string(filepath.Separator)) {
+			continue
+		}
+
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return fmt.Errorf("failed to create directory %s: %w", target, err)
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return fmt.Errorf("failed to create parent dir for %s: %w", target, err)
+			}
+
+			mode := hdr.FileInfo().Mode()
+			out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+			if err != nil {
+				return fmt.Errorf("failed to create file %s: %w", target, err)
+			}
+			if _, err := io.Copy(out, tr); err != nil {
+				out.Close()
+				return fmt.Errorf("failed to write file %s: %w", target, err)
+			}
+			out.Close()
+		}
+	}
+
+	return nil
+}

--- a/internal/installer/registry_test.go
+++ b/internal/installer/registry_test.go
@@ -1,0 +1,129 @@
+package installer
+
+import (
+	"crypto/sha512"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DriftrLabs/driftr/internal/version"
+)
+
+func TestParseSRI_Valid(t *testing.T) {
+	// A known sha512 hash in SRI format.
+	rawHash := make([]byte, 64) // 512 bits = 64 bytes
+	rawHash[0] = 0xAB
+	rawHash[63] = 0xCD
+	b64 := base64.StdEncoding.EncodeToString(rawHash)
+	sri := "sha512-" + b64
+
+	algo, hash, err := parseSRI(sri)
+	if err != nil {
+		t.Fatalf("parseSRI() error: %v", err)
+	}
+	if algo != "sha512" {
+		t.Errorf("algo = %q, want %q", algo, "sha512")
+	}
+	if len(hash) != 64 {
+		t.Errorf("hash length = %d, want 64", len(hash))
+	}
+	if hash[0] != 0xAB || hash[63] != 0xCD {
+		t.Error("hash content mismatch")
+	}
+}
+
+func TestParseSRI_Invalid(t *testing.T) {
+	tests := []string{
+		"",
+		"sha512",
+		"nohyphen",
+		"sha512-!!!invalid-base64!!!",
+	}
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			_, _, err := parseSRI(input)
+			if err == nil {
+				t.Errorf("parseSRI(%q) expected error, got nil", input)
+			}
+		})
+	}
+}
+
+func TestVerifyIntegrity_Valid(t *testing.T) {
+	dir := t.TempDir()
+	content := []byte("hello npm registry")
+	path := filepath.Join(dir, "test.tgz")
+
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	h := sha512.Sum512(content)
+	integrity := "sha512-" + base64.StdEncoding.EncodeToString(h[:])
+
+	if err := VerifyIntegrity(path, integrity); err != nil {
+		t.Fatalf("VerifyIntegrity() error: %v", err)
+	}
+}
+
+func TestVerifyIntegrity_Mismatch(t *testing.T) {
+	dir := t.TempDir()
+	content := []byte("hello npm registry")
+	path := filepath.Join(dir, "test.tgz")
+
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	// Use a wrong hash.
+	wrongHash := make([]byte, 64)
+	integrity := "sha512-" + base64.StdEncoding.EncodeToString(wrongHash)
+
+	err := VerifyIntegrity(path, integrity)
+	if err == nil {
+		t.Fatal("expected integrity mismatch error, got nil")
+	}
+}
+
+func TestVerifyIntegrity_UnsupportedAlgo(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.tgz")
+	if err := os.WriteFile(path, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := VerifyIntegrity(path, "sha256-AAAA")
+	if err == nil {
+		t.Fatal("expected unsupported algorithm error, got nil")
+	}
+}
+
+func TestVersionGreater(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want bool
+	}{
+		{"2.0.0", "1.0.0", true},
+		{"1.1.0", "1.0.0", true},
+		{"1.0.1", "1.0.0", true},
+		{"1.0.0", "1.0.0", false},
+		{"1.0.0", "2.0.0", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.a+"_vs_"+tt.b, func(t *testing.T) {
+			a, err := version.Parse(tt.a)
+			if err != nil {
+				t.Fatalf("Parse(%q) error: %v", tt.a, err)
+			}
+			b, err := version.Parse(tt.b)
+			if err != nil {
+				t.Fatalf("Parse(%q) error: %v", tt.b, err)
+			}
+			if got := versionGreater(a, b); got != tt.want {
+				t.Errorf("versionGreater(%s, %s) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/installer/registry.go` — shared npm registry client for downloading packages from `registry.npmjs.org`
- Adds `internal/installer/registry_extract.go` — extracts npm `.tgz` tarballs with `package/` prefix stripping and path traversal protection
- Adds `internal/installer/registry_test.go` — unit tests for SRI parsing, integrity verification, and version comparison

### New functions
- `FetchRegistryVersion(pkg, ver)` — fetch specific version metadata
- `ResolveRegistryLatest(pkg, v)` — find latest version matching partial spec via dist-tags or version iteration
- `DownloadRegistryPackage(pkg, ver, verbose)` — download tarball to cache with progress reporting
- `VerifyIntegrity(path, integrity)` — SHA-512 SRI integrity verification
- `ExtractRegistryPackage(archivePath, destDir)` — extract tarball stripping npm's `package/` prefix

Closes #20