### PR TITLE
feat: add pnpm and yarn version management

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -11,15 +11,15 @@ func newInstallCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "install <tool@version>",
 		Short: "Install a tool version",
-		Long:  "Download and install a specific tool version.\n\nExamples:\n  driftr install node@24\n  driftr install node@22.14.0\n  driftr install node@latest",
+		Long:  "Download and install a specific tool version.\n\nExamples:\n  driftr install node@24\n  driftr install pnpm@9\n  driftr install yarn@1\n  driftr install node@latest",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			spec := args[0]
-			tool, _ := parseToolVersion(spec)
+			tool, versionSpec := parseToolVersion(spec)
 
 			fmt.Printf("Installing %s...\n", spec)
 
-			resolved, err := installer.Install(spec, verbose)
+			resolved, err := installTool(tool, versionSpec, verbose)
 			if err != nil {
 				return fmt.Errorf("installation failed: %w", err)
 			}
@@ -27,5 +27,21 @@ func newInstallCmd() *cobra.Command {
 			fmt.Printf("Installed %s %s\n", tool, resolved)
 			return nil
 		},
+	}
+}
+
+func installTool(tool, versionSpec string, verbose bool) (string, error) {
+	// Reconstruct the spec for installers that expect "tool@version" format.
+	spec := tool + "@" + versionSpec
+
+	switch tool {
+	case "node":
+		return installer.Install(spec, verbose)
+	case "pnpm":
+		return installer.InstallPnpm(versionSpec, verbose)
+	case "yarn":
+		return installer.InstallYarn(versionSpec, verbose)
+	default:
+		return "", fmt.Errorf("unknown tool: %s. Supported tools: node, pnpm, yarn", tool)
 	}
 }

--- a/internal/installer/pnpm.go
+++ b/internal/installer/pnpm.go
@@ -1,0 +1,186 @@
+package installer
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/DriftrLabs/driftr/internal/platform"
+	"github.com/DriftrLabs/driftr/internal/version"
+)
+
+const pnpmGitHubRepo = "pnpm/pnpm"
+
+// InstallPnpm downloads and installs a pnpm version.
+// Uses the standalone binary from GitHub releases.
+func InstallPnpm(versionStr string, verbose bool) (string, error) {
+	if err := platform.EnsureToolDirs("pnpm"); err != nil {
+		return "", err
+	}
+
+	v, err := version.Parse(versionStr)
+	if err != nil {
+		return "", fmt.Errorf("invalid version: %w", err)
+	}
+
+	// Resolve partial versions via npm registry (pnpm publishes there too).
+	resolvedVersion := v.String()
+	if v.Latest || v.IsPartial() {
+		resolved, err := ResolveRegistryLatest("pnpm", v)
+		if err != nil {
+			return "", err
+		}
+		resolvedVersion = resolved
+		if verbose {
+			fmt.Printf("  Resolved %s to %s\n", versionStr, resolvedVersion)
+		}
+	}
+
+	// Check if already installed.
+	binPath, err := platform.ToolBinary("pnpm", resolvedVersion)
+	if err != nil {
+		return "", err
+	}
+	if _, err := os.Stat(binPath); err == nil {
+		if verbose {
+			fmt.Printf("  pnpm %s is already installed\n", resolvedVersion)
+		}
+		return resolvedVersion, nil
+	}
+
+	// Download standalone binary from GitHub releases.
+	archivePath, err := downloadPnpmBinary(resolvedVersion, verbose)
+	if err != nil {
+		return "", err
+	}
+
+	// Install: create version dir and copy binary.
+	versionDir, err := platform.ToolVersionDir("pnpm", resolvedVersion)
+	if err != nil {
+		return "", err
+	}
+
+	binDir := filepath.Join(versionDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		return "", fmt.Errorf("failed to create pnpm bin dir: %w", err)
+	}
+
+	destPath := filepath.Join(binDir, "pnpm")
+	if err := copyFile(archivePath, destPath); err != nil {
+		os.RemoveAll(versionDir)
+		return "", fmt.Errorf("failed to install pnpm binary: %w", err)
+	}
+	if err := os.Chmod(destPath, 0o755); err != nil {
+		os.RemoveAll(versionDir)
+		return "", err
+	}
+
+	// Create pnpx symlink pointing to pnpm.
+	pnpxPath := filepath.Join(binDir, "pnpx")
+	os.Remove(pnpxPath) // remove if exists
+	if err := os.Symlink("pnpm", pnpxPath); err != nil {
+		// Fallback: copy the binary if symlink fails.
+		if err := copyFile(destPath, pnpxPath); err != nil {
+			return "", fmt.Errorf("failed to create pnpx: %w", err)
+		}
+	}
+
+	return resolvedVersion, nil
+}
+
+// pnpmBinaryURL returns the GitHub releases URL for the standalone pnpm binary.
+func pnpmBinaryURL(ver string) string {
+	osName := runtime.GOOS
+	archName := runtime.GOARCH
+	// pnpm uses "x64" for amd64.
+	if archName == "amd64" {
+		archName = "x64"
+	}
+	return fmt.Sprintf("https://github.com/%s/releases/download/v%s/pnpm-%s-%s",
+		pnpmGitHubRepo, ver, osName, archName)
+}
+
+func downloadPnpmBinary(ver string, verbose bool) (string, error) {
+	cacheDir, err := platform.CacheDir()
+	if err != nil {
+		return "", err
+	}
+
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return "", fmt.Errorf("failed to create cache dir: %w", err)
+	}
+
+	filename := fmt.Sprintf("pnpm-%s-%s-%s", ver, runtime.GOOS, runtime.GOARCH)
+	destPath := filepath.Join(cacheDir, filename)
+
+	// Skip if cached.
+	if info, err := os.Stat(destPath); err == nil && info.Size() > 0 {
+		if verbose {
+			fmt.Printf("  Using cached binary: %s\n", destPath)
+		}
+		return destPath, nil
+	}
+
+	url := pnpmBinaryURL(ver)
+	if verbose {
+		fmt.Printf("  Downloading: %s\n", url)
+	}
+
+	resp, err := httpClient.Get(url)
+	if err != nil {
+		return "", fmt.Errorf("download failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 404 {
+		return "", fmt.Errorf("pnpm %s standalone binary not found for %s/%s", ver, runtime.GOOS, runtime.GOARCH)
+	}
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("download failed with status %d", resp.StatusCode)
+	}
+
+	tmpFile, err := os.CreateTemp(cacheDir, "driftr-pnpm-*")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+
+	if isTerminal(os.Stderr) {
+		pw := &progressWriter{dest: tmpFile, total: resp.ContentLength}
+		_, err = io.Copy(pw, resp.Body)
+		pw.finish()
+	} else {
+		_, err = io.Copy(tmpFile, resp.Body)
+	}
+	tmpFile.Close()
+	if err != nil {
+		os.Remove(tmpPath)
+		return "", fmt.Errorf("download interrupted: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, destPath); err != nil {
+		os.Remove(tmpPath)
+		return "", fmt.Errorf("failed to save binary: %w", err)
+	}
+
+	return destPath, nil
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, in)
+	return err
+}

--- a/internal/installer/yarn.go
+++ b/internal/installer/yarn.go
@@ -1,0 +1,90 @@
+package installer
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/DriftrLabs/driftr/internal/platform"
+	"github.com/DriftrLabs/driftr/internal/version"
+)
+
+// InstallYarn downloads and installs a yarn version from the npm registry.
+func InstallYarn(versionStr string, verbose bool) (string, error) {
+	if err := platform.EnsureToolDirs("yarn"); err != nil {
+		return "", err
+	}
+
+	v, err := version.Parse(versionStr)
+	if err != nil {
+		return "", fmt.Errorf("invalid version: %w", err)
+	}
+
+	// Resolve partial versions via npm registry.
+	resolvedVersion := v.String()
+	if v.Latest || v.IsPartial() {
+		resolved, err := ResolveRegistryLatest("yarn", v)
+		if err != nil {
+			return "", err
+		}
+		resolvedVersion = resolved
+		if verbose {
+			fmt.Printf("  Resolved %s to %s\n", versionStr, resolvedVersion)
+		}
+	}
+
+	// Check if already installed.
+	binPath, err := platform.ToolBinary("yarn", resolvedVersion)
+	if err != nil {
+		return "", err
+	}
+	if _, err := os.Stat(binPath); err == nil {
+		if verbose {
+			fmt.Printf("  yarn %s is already installed\n", resolvedVersion)
+		}
+		return resolvedVersion, nil
+	}
+
+	// Download from npm registry.
+	archivePath, rv, err := DownloadRegistryPackage("yarn", resolvedVersion, verbose)
+	if err != nil {
+		return "", err
+	}
+
+	// Verify integrity.
+	if rv.Dist.Integrity != "" {
+		if verbose {
+			fmt.Println("  Verifying integrity...")
+		}
+		if err := VerifyIntegrity(archivePath, rv.Dist.Integrity); err != nil {
+			os.Remove(archivePath)
+			return "", err
+		}
+	}
+
+	// Extract to version directory.
+	versionDir, err := platform.ToolVersionDir("yarn", resolvedVersion)
+	if err != nil {
+		return "", err
+	}
+
+	if verbose {
+		fmt.Printf("  Extracting to: %s\n", versionDir)
+	}
+	if err := ExtractRegistryPackage(archivePath, versionDir); err != nil {
+		os.RemoveAll(versionDir)
+		return "", fmt.Errorf("extraction failed: %w", err)
+	}
+
+	// Verify the binary exists after extraction.
+	if _, err := os.Stat(binPath); os.IsNotExist(err) {
+		os.RemoveAll(versionDir)
+		return "", fmt.Errorf("yarn binary not found after extraction at %s", binPath)
+	}
+
+	// Ensure the binary is executable.
+	if err := os.Chmod(binPath, 0o755); err != nil {
+		return "", err
+	}
+
+	return resolvedVersion, nil
+}

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -147,6 +147,9 @@ var toolBinaryMap = map[string]struct {
 	"node": {parent: "node", binary: "node"},
 	"npm":  {parent: "node", binary: "npm"},
 	"npx":  {parent: "node", binary: "npx"},
+	"pnpm": {parent: "pnpm", binary: "pnpm"},
+	"pnpx": {parent: "pnpm", binary: "pnpx"},
+	"yarn": {parent: "yarn", binary: "yarn"},
 }
 
 // ToolBinary returns the binary path for a given tool and version.

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -331,9 +331,23 @@ func resolveFromGlobal(tool string) (*Resolution, error) {
 	}, nil
 }
 
-// ResolveBinary resolves the full path to a tool binary (node, npm, npx).
+// toolParent maps tools to the parent tool whose version controls resolution.
+// Tools not listed here resolve independently.
+var toolParent = map[string]string{
+	"npm": "node",
+	"npx": "node",
+}
+
+// ResolveBinary resolves the full path to a tool binary.
+// For bundled tools (npm, npx), resolves via the parent tool (node).
+// For standalone tools (node, pnpm, yarn), resolves via their own version.
 func ResolveBinary(tool string, explicit string) (string, error) {
-	res, err := ResolveNode(explicit)
+	resolveTool := tool
+	if parent, ok := toolParent[tool]; ok {
+		resolveTool = parent
+	}
+
+	res, err := ResolveTool(resolveTool, explicit, false)
 	if err != nil {
 		return "", err
 	}

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -9,7 +9,7 @@ import (
 )
 
 // shimTools lists the tools for which shims are created in MVP.
-var shimTools = []string{"node", "npm", "npx"}
+var shimTools = []string{"node", "npm", "npx", "pnpm", "pnpx", "yarn"}
 
 // GenerateShims creates shim shell scripts in ~/.driftr/bin/.
 // Each shim invokes `driftr shim <tool>` to resolve and exec the real binary.


### PR DESCRIPTION
## Summary

Adds full install/default/pin/list/which support for pnpm and yarn alongside Node.js.

### pnpm (#21)
- Standalone binary from GitHub releases (`pnpm-<os>-<arch>`)
- Partial version resolution via npm registry (`pnpm@9` → latest 9.x)
- Creates `pnpx` symlink alongside pnpm binary
- Storage: `~/.driftr/tools/pnpm/<version>/bin/pnpm`

### yarn (#22)
- Downloads from npm registry, verifies SHA-512 SRI integrity
- Extracts `.tgz` tarball stripping `package/` prefix
- Storage: `~/.driftr/tools/yarn/<version>/bin/yarn`

### Infrastructure changes
- `toolBinaryMap`: added pnpm, pnpx, yarn entries (standalone — parent is self, not node)
- `shimTools`: added pnpm, pnpx, yarn shim generation
- `ResolveBinary()`: now routes through `toolParent` map — npm/npx resolve via node, pnpm/yarn resolve independently
- `install.go`: routes `tool@version` to the correct installer (`InstallPnpm`, `InstallYarn`, or `Install`)

Closes #21, closes #22