### PR TITLE
feat: toolchain binding — co-resolve package managers with Node.js

### DIFF
--- a/internal/cli/shim_cmd.go
+++ b/internal/cli/shim_cmd.go
@@ -22,13 +22,19 @@ func newShimCmd() *cobra.Command {
 			tool := args[0]
 			toolArgs := args[1:]
 
-			binPath, err := resolver.ResolveBinary(tool, "")
+			rb, err := resolver.ResolveBinaryFull(tool, "")
 			if err != nil {
 				return fmt.Errorf("error: %w", err)
 			}
 
-			// Use Exec to replace the process — preserves exit code, stdio, signals.
-			return process.Exec(binPath, toolArgs)
+			// For tools that need Node.js (e.g. yarn), exec node with the tool script.
+			if rb.NodePath != "" {
+				nodeArgs := append([]string{rb.ToolPath}, toolArgs...)
+				return process.Exec(rb.NodePath, nodeArgs)
+			}
+
+			// Standalone tools exec directly.
+			return process.Exec(rb.ToolPath, toolArgs)
 		},
 	}
 }

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -138,18 +138,27 @@ func OS() string {
 	}
 }
 
-// toolBinaryMap maps tool names to their parent tool (for tools bundled with node)
-// and binary name within the version directory.
-var toolBinaryMap = map[string]struct {
-	parent string // which tool's version dir contains this binary
-	binary string // binary name under bin/
-}{
-	"node": {parent: "node", binary: "node"},
-	"npm":  {parent: "node", binary: "npm"},
-	"npx":  {parent: "node", binary: "npx"},
-	"pnpm": {parent: "pnpm", binary: "pnpm"},
-	"pnpx": {parent: "pnpm", binary: "pnpx"},
-	"yarn": {parent: "yarn", binary: "yarn"},
+// ToolEntry describes how to find and execute a tool binary.
+type ToolEntry struct {
+	Parent    string // which tool's version dir contains this binary
+	Binary    string // binary name under bin/
+	NeedsNode bool   // true if the binary is a JS script requiring node to execute
+}
+
+// toolBinaryMap maps tool names to their parent tool and binary info.
+var toolBinaryMap = map[string]ToolEntry{
+	"node": {Parent: "node", Binary: "node"},
+	"npm":  {Parent: "node", Binary: "npm"},
+	"npx":  {Parent: "node", Binary: "npx"},
+	"pnpm": {Parent: "pnpm", Binary: "pnpm"},
+	"pnpx": {Parent: "pnpm", Binary: "pnpx"},
+	"yarn": {Parent: "yarn", Binary: "yarn.js", NeedsNode: true},
+}
+
+// LookupTool returns the ToolEntry for a tool, or false if unknown.
+func LookupTool(tool string) (ToolEntry, bool) {
+	entry, ok := toolBinaryMap[tool]
+	return entry, ok
 }
 
 // ToolBinary returns the binary path for a given tool and version.
@@ -159,11 +168,11 @@ func ToolBinary(tool, version string) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("unknown tool: %s", tool)
 	}
-	dir, err := ToolVersionDir(entry.parent, version)
+	dir, err := ToolVersionDir(entry.Parent, version)
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(dir, "bin", entry.binary), nil
+	return filepath.Join(dir, "bin", entry.Binary), nil
 }
 
 // ArchiveExt returns the archive extension for the current platform.

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -338,10 +338,26 @@ var toolParent = map[string]string{
 	"npx": "node",
 }
 
+// ResolvedBinary holds the result of resolving a tool binary.
+type ResolvedBinary struct {
+	ToolPath string // path to the tool binary
+	NodePath string // path to node binary, set when the tool needs node to execute
+}
+
 // ResolveBinary resolves the full path to a tool binary.
 // For bundled tools (npm, npx), resolves via the parent tool (node).
 // For standalone tools (node, pnpm, yarn), resolves via their own version.
 func ResolveBinary(tool string, explicit string) (string, error) {
+	rb, err := ResolveBinaryFull(tool, explicit)
+	if err != nil {
+		return "", err
+	}
+	return rb.ToolPath, nil
+}
+
+// ResolveBinaryFull resolves a tool binary with dual resolution.
+// For tools that need Node.js (e.g. yarn), it also resolves the Node binary path.
+func ResolveBinaryFull(tool string, explicit string) (*ResolvedBinary, error) {
 	resolveTool := tool
 	if parent, ok := toolParent[tool]; ok {
 		resolveTool = parent
@@ -349,7 +365,29 @@ func ResolveBinary(tool string, explicit string) (string, error) {
 
 	res, err := ResolveTool(resolveTool, explicit, false)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return platform.ToolBinary(tool, res.Version)
+
+	toolPath, err := platform.ToolBinary(tool, res.Version)
+	if err != nil {
+		return nil, err
+	}
+
+	rb := &ResolvedBinary{ToolPath: toolPath}
+
+	// Check if this tool needs Node.js to execute.
+	entry, ok := platform.LookupTool(tool)
+	if ok && entry.NeedsNode {
+		nodeRes, err := ResolveTool("node", "", false)
+		if err != nil {
+			return nil, fmt.Errorf("%s requires Node.js: %w", tool, err)
+		}
+		nodePath, err := platform.ToolBinary("node", nodeRes.Version)
+		if err != nil {
+			return nil, err
+		}
+		rb.NodePath = nodePath
+	}
+
+	return rb, nil
 }


### PR DESCRIPTION
## Summary

Tools that need Node.js to execute (e.g. yarn) now automatically resolve the Node binary alongside their own version via dual resolution.

### How it works

```
~/.driftr/bin/yarn (shim)
  → driftr shim yarn "$@"
    → ResolveBinaryFull("yarn", "")
      → resolve yarn version → 1.22.22 (from .driftr.toml)
      → yarn.NeedsNode == true
      → resolve node version → 24.0.0 (from same config or global default)
    → syscall.Exec(node, [node, yarn.js, args...], env)
```

### Changes

- **`platform.go`**: `ToolEntry` struct with exported fields + `NeedsNode bool` field. `LookupTool()` accessor. Fixed yarn binary path to `yarn.js`.
- **`resolver.go`**: `ResolvedBinary` struct with `ToolPath` + optional `NodePath`. `ResolveBinaryFull()` handles dual resolution. Existing `ResolveBinary()` is a thin wrapper.
- **`shim_cmd.go`**: Uses `ResolveBinaryFull()`. If `NodePath` is set, execs `node <tool-script> args...`. Otherwise execs the tool directly.

### Resolution rules

| Scenario | Behavior |
|----------|----------|
| yarn pinned + node pinned | Both resolved, exec `node yarn.js` |
| yarn pinned, no node pinned | Node falls through to global default |
| yarn pinned, no node anywhere | Error: "yarn requires Node.js: no node version configured..." |
| pnpm (standalone binary) | Exec directly, no Node resolution |
| node / npm / npx | Exec directly (npm/npx are bundled with node) |

Closes #23