### PR TITLE
docs: update all documentation for multi-tool support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">Driftr</h1>
 
 <p align="center">
-  <strong>Fast Node.js versioning without the friction.</strong>
+  <strong>Fast JavaScript toolchain versioning without the friction.</strong>
 </p>
 
 <p align="center">
@@ -17,15 +17,16 @@
 
 ## Why Driftr?
 
-[Volta is no longer maintained.](https://github.com/volta-cli/volta/issues/2080) If you liked Volta's "pin and forget" model -- where `node` and `npm` just work without manual switching -- Driftr carries that torch forward.
+[Volta is no longer maintained.](https://github.com/volta-cli/volta/issues/2080) If you liked Volta's "pin and forget" model -- where `node`, `pnpm`, and `yarn` just work without manual switching -- Driftr carries that torch forward.
 
 Driftr is a new project. It doesn't have Volta's years of polish or fnm's community size. But it has a clean foundation, an honest design, and an active maintainer who actually uses it. If you're looking for something simple that does the job, give it a try. If it's missing something you need, [open an issue](https://github.com/DriftrLabs/Driftr/issues) -- we're listening.
 
-- **Shim-based** -- `node`, `npm`, and `npx` just work, resolved per-project or globally
+- **Multi-tool** -- manages Node.js, pnpm, and yarn from a single CLI
+- **Shim-based** -- `node`, `npm`, `npx`, `pnpm`, `pnpx`, and `yarn` just work, resolved per-project or globally
 - **Fast** -- near-zero overhead via `syscall.Exec` process replacement
 - **Minimal** -- 2 external dependencies (cobra + toml), everything else is Go stdlib
 - **Deterministic** -- explicit resolution chain: project config > `package.json` > global default
-- **Secure** -- SHA256 checksum verification on every download
+- **Secure** -- SHA256 and SHA-512 SRI checksum verification on every download
 - **Simple** -- a handful of commands cover the entire workflow
 
 ## Install
@@ -39,31 +40,37 @@ This downloads the latest release, verifies its checksum, and configures your PA
 ## Quick Start
 
 ```bash
-# Install Node.js
+# Install your toolchain
 driftr install node@22
+driftr install pnpm@9
+driftr install yarn@1
 
-# Set global default
+# Set global defaults
 driftr default node@22.22.0
+driftr default pnpm@9.15.0
 
 # Pin a project (prompts for .driftr.toml or package.json on first use)
 cd my-project
 driftr pin node@22.22.0
+driftr pin pnpm@9.15.0
 
-# It just works
-node -v  # resolves automatically
+# Everything just works
+node -v   # resolves automatically
+pnpm -v   # resolves automatically
 ```
 
 ## Commands
 
 | Command | Description |
 |---------|-------------|
-| `driftr install node@<version>` | Download and install a Node.js version |
-| `driftr default node@<version>` | Set the global default version |
-| `driftr pin node@<version>` | Pin a version to the current project (`.driftr.toml` or `package.json`) |
-| `driftr list` | List installed versions |
-| `driftr which node` | Show which binary would be executed and why |
-| `driftr run --node <ver> -- <cmd>` | Run a command under a specific version |
+| `driftr install <tool@version>` | Download and install a tool version (node, pnpm, yarn) |
+| `driftr default <tool@version>` | Set the global default version for a tool |
+| `driftr pin <tool@version>` | Pin a version to the current project (`.driftr.toml` or `package.json`) |
+| `driftr list [tool]` | List installed versions (defaults to node) |
+| `driftr which <tool>` | Show which binary would be executed and why |
+| `driftr run --node <ver> -- <cmd>` | Run a command under a specific Node.js version |
 | `driftr setup` | Initialize Driftr and generate shims |
+| `driftr update` | Update Driftr to the latest version |
 
 All commands support `-v` / `--verbose` for detailed output including resolver tracing and checksum details.
 
@@ -93,7 +100,7 @@ flowchart TD
     C1 & C2 & C3 & C4 --> D["syscall.Exec\nreplaces process with real node"]
 ```
 
-The shim in `~/.driftr/bin/node` intercepts calls, the resolver determines the correct version, and `syscall.Exec` replaces the process with the real Node.js binary. No child process, no signal forwarding, no overhead.
+Shims in `~/.driftr/bin/` intercept calls to `node`, `npm`, `npx`, `pnpm`, `pnpx`, and `yarn`. The resolver determines the correct version, and `syscall.Exec` replaces the process with the real binary. Standalone tools (node, pnpm) are exec'd directly. Tools that need Node.js (yarn) are exec'd as `node <tool-script>`.
 
 ## Documentation
 
@@ -109,13 +116,14 @@ The shim in `~/.driftr/bin/node` intercepts calls, the resolver determines the c
 
 ```
 ~/.driftr/
-  bin/              shims (node, npm, npx)
-  tools/node/       installed Node.js versions
-    22.22.0/
-    24.0.0/
+  bin/              shims (node, npm, npx, pnpm, pnpx, yarn)
+  tools/
+    node/           installed Node.js versions
+    pnpm/           installed pnpm versions
+    yarn/           installed yarn versions
   config/
     config.toml     global default settings
-  cache/            downloaded archives
+  cache/            downloaded archives + binaries
 ```
 
 ## How Driftr Compares
@@ -128,11 +136,11 @@ The shim in `~/.driftr/bin/node` intercepts calls, the resolver determines the c
 | External dependencies | **2** | 0 (shell) | ~36 crates | 24 crates | 113 crates |
 | macOS / Linux | Yes | Yes | Yes | Yes | Yes |
 | Windows | No | No | Yes (rough) | Yes | Very basic |
-| Manages npm/pnpm/yarn | Planned | No | Partial | No | Yes |
+| Manages npm/pnpm/yarn | **Yes** | No | Partial | No | Yes |
 | Maintained | Yes | Yes | **No** | Yes | Yes |
 | Self-update | `driftr update` | `nvm` script | No | No | `mise self-update` |
 
-**When to choose Driftr**: You want a fast, minimal, shim-based Node.js manager with a Volta-like experience -- pin versions to projects, and `node` just works. You value simplicity and a small dependency footprint.
+**When to choose Driftr**: You want a fast, minimal, shim-based manager for Node.js, pnpm, and yarn with a Volta-like experience -- pin versions to projects, and tools just work. You value simplicity and a small dependency footprint.
 
 **When to choose something else**: If you need Windows support, fnm is your best bet. If you want one tool for Node + Python + Ruby + everything else, mise is the polyglot option. If nvm already works for you and startup time doesn't bother you, there's no reason to switch.
 
@@ -140,7 +148,7 @@ The shim in `~/.driftr/bin/node` intercepts calls, the resolver determines the c
 
 - macOS or Linux
 - `curl` or `wget` (for the install script)
-- Internet access (to download Node.js releases from nodejs.org)
+- Internet access (to download releases from nodejs.org, GitHub, and the npm registry)
 - Go 1.23+ (only if building from source)
 
 ## License

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,9 @@ This document describes Driftr's internal design for contributors and anyone cur
 
 ## Overview
 
-Driftr is a shim-based toolchain manager. When you type `node`, a lightweight shim intercepts the call, resolves the correct Node.js version, and replaces itself with the real binary using `syscall.Exec`. The entire resolution happens in single-digit milliseconds.
+Driftr is a shim-based toolchain manager. When you type `node`, `pnpm`, or `yarn`, a lightweight shim intercepts the call, resolves the correct version, and replaces itself with the real binary using `syscall.Exec`. The entire resolution happens in single-digit milliseconds.
+
+Standalone tools (node, pnpm) are exec'd directly. Tools that need Node.js to run (yarn) are exec'd as `node <tool-script>`.
 
 ```mermaid
 flowchart TD
@@ -37,26 +39,33 @@ internal/
     project.go              .driftr.toml read/write + directory walk
     packagejson.go          package.json driftr key read/write
 
-  installer/                Node.js installation pipeline
-    node.go                 orchestrates install: resolve → download → verify → extract
-    download.go             HTTP download with caching
+  installer/                tool installation pipelines
+    node.go                 Node.js: resolve → download → verify SHA256 → extract
+    pnpm.go                 pnpm: resolve → download standalone binary from GitHub
+    yarn.go                 yarn: resolve → download from npm registry → verify SRI → extract
+    registry.go             npm registry client: version resolution, tarball download, SRI verification
+    registry_extract.go     tarball extraction for npm registry packages
+    download.go             HTTP download with caching and progress reporting
     extract.go              tar.gz extraction with path sanitization
     checksum.go             SHA256 verification against SHASUMS256.txt
 
   resolver/                 version resolution engine
-    resolver.go             resolution chain: explicit → project → package.json → global
+    resolver.go             generic resolution: ResolveTool(), ResolveBinaryFull() with dual resolution
 
   shim/                     shim script generation
-    shim.go                 creates shell scripts in ~/.driftr/bin/
+    shim.go                 creates shell scripts in ~/.driftr/bin/ (node, npm, npx, pnpm, pnpx, yarn)
 
   process/                  process execution
     exec.go                 syscall.Exec (replace) and exec.Command (child)
 
   platform/                 OS and architecture abstraction
-    platform.go             paths, directories, OS/arch detection
+    platform.go             paths, directories, OS/arch detection, toolBinaryMap
 
   version/                  version string parsing
-    version.go              semver parsing with partial version support
+    version.go              semver parsing with partial version and tool@ prefix support
+
+  updater/                  self-update mechanism
+    updater.go              checks GitHub releases, downloads and replaces binary
 ```
 
 ## Key Design Decisions
@@ -70,13 +79,18 @@ Shims are simple shell scripts:
 exec "/usr/local/bin/driftr" shim node "$@"
 ```
 
-The `exec` replaces the shell process with `driftr`, and then `driftr` uses `syscall.Exec` to replace itself with the real `node` binary. This double-exec means:
+Shims exist for `node`, `npm`, `npx`, `pnpm`, `pnpx`, and `yarn`. The `exec` replaces the shell process with `driftr`, and then `driftr` uses `syscall.Exec` to replace itself with the real binary. This double-exec means:
 
 - No child process management
 - Exit codes pass through natively
 - stdin/stdout/stderr are preserved
 - Signal handling is handled by the OS
 - Near-zero latency overhead
+
+There are two execution modes:
+
+1. **Direct exec** (node, pnpm): `syscall.Exec(tool-binary, args, env)`
+2. **Node-wrapped exec** (yarn): `syscall.Exec(node, [yarn.js, args...], env)` — because yarn is a JS script that needs Node.js to run. The Node version is co-resolved from the same config.
 
 ### `DisableFlagParsing` on Shim Command
 
@@ -93,20 +107,22 @@ The resolver follows a strict priority order:
 
 In each directory, `.driftr.toml` is checked before `package.json`. The closest config to the working directory wins, regardless of format.
 
-There is no system fallback by default. If no version is configured, Driftr returns an actionable error message. This is intentional: implicit fallback to a system Node would undermine the determinism guarantee.
+Each tool resolves independently: `npm`/`npx` resolve via node's version (bundled), `pnpm`/`pnpx` via pnpm's version, and `yarn` via yarn's version. There is no system fallback — if no version is configured, Driftr returns an actionable error.
 
 ### Partial Version Resolution
 
-When a user types `driftr install node@22`, Driftr queries the Node.js release index at `https://nodejs.org/dist/index.json` and picks the latest release matching major version 22. The index is sorted newest-first, so the first match is always the latest.
+Partial versions (e.g. `node@22`, `pnpm@9`) are resolved to the latest matching release:
+
+- **Node.js**: queries `nodejs.org/dist/index.json`
+- **pnpm/yarn**: queries the npm registry at `registry.npmjs.org/<package>`
 
 ### Checksum Verification
 
-Every download is verified:
-
-1. Fetch `SHASUMS256.txt` from `nodejs.org/dist/v<version>/`
-2. Find the line matching the archive filename
-3. Compute SHA256 of the local file
-4. Compare -- fail with an actionable error if they differ
+| Tool    | Method                                            |
+|---------|---------------------------------------------------|
+| Node.js | SHA256 against `SHASUMS256.txt` from nodejs.org   |
+| pnpm    | No verification (standalone binary from GitHub)   |
+| yarn    | SHA-512 SRI integrity from npm registry metadata  |
 
 On failure, the cached archive is deleted so the next attempt re-downloads.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,20 +6,26 @@ Driftr uses configuration at two levels: global (`config.toml`) and per-project 
 
 **Location:** `~/.driftr/config/config.toml`
 
-This file stores your global default Node.js version. It is created and managed by `driftr default`.
+This file stores your global default tool versions. It is created and managed by `driftr default`.
 
 ### Format
 
 ```toml
 [default]
 node = "22.14.0"
+
+[default.tools]
+pnpm = "9.15.0"
+yarn = "1.22.22"
 ```
 
 ### Fields
 
-| Section | Key | Type | Description |
-|---------|-----|------|-------------|
-| `[default]` | `node` | string | Global default Node.js version |
+| Section           | Key    | Type   | Description                     |
+|-------------------|--------|--------|---------------------------------|
+| `[default]`       | `node` | string | Global default Node.js version  |
+| `[default.tools]` | `pnpm` | string | Global default pnpm version     |
+| `[default.tools]` | `yarn` | string | Global default yarn version     |
 
 ### Example
 
@@ -27,14 +33,10 @@ After running:
 
 ```bash
 driftr default node@22.14.0
+driftr default pnpm@9.15.0
 ```
 
-The config file will contain:
-
-```toml
-[default]
-node = "22.14.0"
-```
+The config file will contain both tool defaults.
 
 ## Project Configuration
 
@@ -47,11 +49,14 @@ Driftr supports two project config formats. On first `driftr pin`, you choose wh
 ```toml
 [tools]
 node = "22.14.0"
+pnpm = "9.15.0"
 ```
 
-| Section | Key | Type | Description |
-|---------|-----|------|-------------|
-| `[tools]` | `node` | string | Pinned Node.js version for this project |
+| Section   | Key    | Type   | Description                                |
+|-----------|--------|--------|--------------------------------------------|
+| `[tools]` | `node` | string | Pinned Node.js version for this project    |
+| `[tools]` | `pnpm` | string | Pinned pnpm version for this project       |
+| `[tools]` | `yarn` | string | Pinned yarn version for this project       |
 
 ### Option 2: `package.json`
 
@@ -71,6 +76,8 @@ node = "22.14.0"
 | `driftr.node`  | string | Pinned Node.js version for this project  |
 
 This format is useful when you want to keep all project tooling config in `package.json` without an extra dotfile.
+
+**Note:** The `package.json` format currently only supports `node`. For pnpm and yarn pinning, use `.driftr.toml`.
 
 **Note:** `package.json` must already exist — Driftr will not create it. Run `npm init` first if needed.
 
@@ -103,7 +110,7 @@ This means:
 
 ### Version Control
 
-Your project config (`.driftr.toml` or `package.json`) **should be committed** to version control. This ensures all team members use the same Node.js version.
+Your project config (`.driftr.toml` or `package.json`) **should be committed** to version control. This ensures all team members use the same tool versions.
 
 ```bash
 git add .driftr.toml   # or package.json
@@ -120,20 +127,27 @@ Driftr stores all data under `~/.driftr/`:
     node                      shell script -> driftr shim node
     npm                       shell script -> driftr shim npm
     npx                       shell script -> driftr shim npx
+    pnpm                      shell script -> driftr shim pnpm
+    pnpx                      shell script -> driftr shim pnpx
+    yarn                      shell script -> driftr shim yarn
   tools/
     node/
-      22.14.0/                extracted Node.js installation
-        bin/
-          node
-          npm
-          npx
+      22.14.0/
+        bin/node, npm, npx
+    pnpm/
+      9.15.0/
+        bin/pnpm, pnpx (symlink)
+    yarn/
+      1.22.22/
+        bin/yarn.js
         lib/
-        include/
-      24.0.0/
+        package.json
   config/
     config.toml               global configuration
   cache/
-    node-v22.14.0-*.tar.gz    cached downloads
+    node-v22.14.0-*.tar.gz    cached Node.js archives
+    pnpm-9.15.0-*             cached pnpm binaries
+    yarn-1.22.22.tgz          cached yarn tarballs
 ```
 
 ### Cache
@@ -150,12 +164,5 @@ driftr install node@22.14.0
 The configuration format is designed for extension. Future versions may add:
 
 - `.nvmrc` and `.node-version` file support as alternative resolution sources
-- Package manager pinning (`pnpm`, `yarn`) in `.driftr.toml` and `package.json`
+- pnpm and yarn pinning in `package.json` format (currently `.driftr.toml` only)
 - Mirror configuration for custom download sources
-
-```toml
-# Future .driftr.toml (not yet supported)
-[tools]
-node = "22.14.0"
-pnpm = "10.0.0"
-```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -44,13 +44,14 @@ go test ./...
 cmd/driftr/          entry point
 internal/
   cli/               CLI commands (cobra)
-  config/            TOML config management
-  installer/         download, checksum, extract
-  resolver/          version resolution chain
-  shim/              shim script generation
+  config/            TOML + JSON config management
+  installer/         tool installers (node, pnpm, yarn) + npm registry client
+  resolver/          generic version resolution chain
+  shim/              shim script generation (node, npm, npx, pnpm, pnpx, yarn)
   process/           process execution (syscall.Exec)
-  platform/          OS/architecture abstraction
-  version/           semver parsing
+  platform/          OS/architecture abstraction, tool binary map
+  version/           semver parsing with tool@ prefix support
+  updater/           self-update mechanism
 docs/                documentation
 test.sh              integration test script
 Dockerfile           production image
@@ -181,24 +182,23 @@ Group tests under numbered section headers to keep them organized.
 
 ### Good First Issues
 
-- Add shell completion scripts (bash, zsh, fish)
 - Improve error messages with suggestions
-- Add `driftr uninstall node@<version>` command
+- Add `driftr uninstall <tool@version>` command
 - Add color output for `driftr list`
+- Add `driftr list --all` to show versions for all tools at once
 
 ### Medium Complexity
 
 - `.nvmrc` and `.node-version` file support in the resolver
 - `driftr doctor` command for environment health checks
-- Download progress bar
-- `driftr self-update` mechanism
+- pnpm and yarn pinning in `package.json` format (currently `.driftr.toml` only)
+- Checksum verification for pnpm standalone binaries
 
 ### Larger Features
 
-- pnpm and yarn version management
-- Package manager pinning in `.driftr.toml`
 - Windows support (`.cmd` shims, `.zip` extraction)
 - Mirror configuration for custom download sources
+- yarn berry (3+/4+) support
 
 ## Reporting Bugs
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -81,10 +81,10 @@ This creates the following structure:
 
 ```
 ~/.driftr/
-  bin/           shim scripts (node, npm, npx)
-  tools/node/    installed Node.js versions
+  bin/           shim scripts (node, npm, npx, pnpm, pnpx, yarn)
+  tools/         installed tool versions
   config/        global configuration
-  cache/         downloaded archives
+  cache/         downloaded archives + binaries
 ```
 
 ## PATH Configuration

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,7 +4,7 @@ All commands support the `-v` / `--verbose` flag for detailed output.
 
 ## driftr install
 
-Download and install a Node.js version.
+Download and install a tool version.
 
 ```bash
 # Install latest Node.js 22.x
@@ -13,48 +13,60 @@ driftr install node@22
 # Install a specific version
 driftr install node@22.14.0
 
+# Install pnpm and yarn
+driftr install pnpm@9
+driftr install yarn@1
+
+# Install the latest version of a tool
+driftr install node@latest
+
 # Verbose output (shows download URL, checksum verification)
 driftr install node@22 -v
 ```
 
-**What happens:**
-1. If a partial version is given (e.g. `22`), Driftr resolves it to the latest matching release by querying the Node.js release index
-2. Downloads the archive from `nodejs.org`
-3. Verifies the SHA256 checksum against the official `SHASUMS256.txt`
-4. Extracts the archive to `~/.driftr/tools/node/<version>/`
+**Install pipelines by tool:**
+
+| Tool    | Source                                 | Verification                  |
+|---------|----------------------------------------|-------------------------------|
+| Node.js | nodejs.org archives                    | SHA256 against SHASUMS256.txt |
+| pnpm    | Standalone binary from GitHub releases | --                            |
+| yarn    | npm registry tarball                   | SHA-512 SRI integrity         |
 
 **Notes:**
 - Reinstalling an already-installed version is a no-op
-- Downloaded archives are cached in `~/.driftr/cache/`
+- Downloaded archives and binaries are cached in `~/.driftr/cache/`
 - If checksum verification fails, the cached archive is deleted automatically
 - If extraction fails, the partial installation is cleaned up
 
 ## driftr default
 
-Set the global default Node.js version.
+Set the global default version for a tool.
 
 ```bash
 driftr default node@22.14.0
+driftr default pnpm@9.15.0
+driftr default yarn@1.22.22
 ```
 
-The global default is used whenever you run `node` outside a project with a pinned version.
+The global default is used whenever you run a tool outside a project with a pinned version.
 
 **Requirements:**
 - The version must already be installed
 
 ## driftr pin
 
-Pin a Node.js version to the current project.
+Pin a tool version to the current project.
 
 ```bash
 cd my-project
 driftr pin node@22.14.0
+driftr pin pnpm@9.15.0
 ```
 
 On first use, Driftr prompts you to choose a storage format:
 
 ```
-No existing project config found. How should the Node.js version be stored?
+No existing project config found. How should the version be stored?
   1) .driftr.toml (recommended)
   2) package.json (driftr key)
 Choose [1/2]:
@@ -65,6 +77,7 @@ Choosing `.driftr.toml` creates:
 ```toml
 [tools]
 node = "22.14.0"
+pnpm = "9.15.0"
 ```
 
 Choosing `package.json` adds a `driftr` key to your existing `package.json`:
@@ -92,6 +105,7 @@ This writes the version in the other format and removes the old config.
 **Requirements:**
 - The version must already be installed
 - `package.json` format requires an existing `package.json` file (run `npm init` first)
+- `package.json` format currently only supports `node`. For pnpm and yarn pinning, use `.driftr.toml`
 
 **Behavior:**
 - Anyone who clones the project and has Driftr set up will automatically use the pinned version
@@ -101,16 +115,18 @@ This writes the version in the other format and removes the old config.
 
 ## driftr list
 
-List all installed Node.js versions.
+List installed versions for a tool. Defaults to node.
 
 ```bash
-driftr list
+driftr list          # list node versions
+driftr list pnpm     # list pnpm versions
+driftr list yarn     # list yarn versions
 ```
 
 Output example:
 
 ```
-Installed Node.js versions:
+Installed node versions:
     20.11.0
   * 22.14.0
     24.0.0
@@ -126,6 +142,8 @@ Show which binary Driftr would execute, and why.
 
 ```bash
 driftr which node
+driftr which pnpm
+driftr which yarn
 ```
 
 Output example:
@@ -147,7 +165,7 @@ driftr which node -v
 This shows each step of the resolution chain:
 
 ```
-  [resolve] Starting Node.js version resolution
+  [resolve] Starting node version resolution
   [resolve] Step 1: No explicit override
   [resolve] Step 2: Searching for project config from /home/user/my-project
   [resolve]   Checking: /home/user/my-project/.driftr.toml
@@ -185,8 +203,8 @@ driftr setup
 ```
 
 **What it creates:**
-- `~/.driftr/bin/` with shims for `node`, `npm`, `npx`
-- `~/.driftr/tools/node/` for installed versions
+- `~/.driftr/bin/` with shims for `node`, `npm`, `npx`, `pnpm`, `pnpx`, `yarn`
+- `~/.driftr/tools/` for installed tool versions
 - `~/.driftr/config/` for global settings
 - `~/.driftr/cache/` for downloads
 
@@ -194,7 +212,7 @@ Run this once after installing Driftr, and again after upgrading to regenerate s
 
 ## Resolution Order
 
-When you run `node` (or `npm`/`npx`), Driftr resolves the version in this order:
+When you run a tool (`node`, `npm`, `npx`, `pnpm`, `pnpx`, or `yarn`), Driftr resolves the version in this order:
 
 | Priority | Source | When |
 |----------|--------|------|
@@ -203,11 +221,13 @@ When you run `node` (or `npm`/`npx`), Driftr resolves the version in this order:
 | 3 | `package.json` driftr key | Found in current or parent directory |
 | 4 | Global default | Set via `driftr default` |
 
-If no version is configured at any level, Driftr prints an actionable error:
+If no version is configured at any level, Driftr prints an actionable error.
 
-```
-no Node.js version configured. Run `driftr install node@<version>` and `driftr default node@<version>`
-```
+**Tool resolution:**
+
+- `npm` and `npx` resolve via the **node** version (they are bundled with Node.js)
+- `pnpm` and `pnpx` resolve via the **pnpm** version (pnpx is a symlink to pnpm)
+- `yarn` resolves via the **yarn** version, and also co-resolves **node** because yarn is a JS script that needs `node` to execute
 
 ## Typical Workflow
 
@@ -217,19 +237,22 @@ driftr setup
 echo 'export PATH="$HOME/.driftr/bin:$PATH"' >> ~/.zshrc
 source ~/.zshrc
 
-# Install versions you need
+# Install your toolchain
 driftr install node@22
-driftr install node@24
+driftr install pnpm@9
+driftr install yarn@1
 
-# Set a global fallback
-driftr default node@24.0.0
+# Set global defaults
+driftr default node@22.14.0
+driftr default pnpm@9.15.0
 
 # Pin projects
-cd project-a && driftr pin node@22.14.0
+cd project-a && driftr pin node@22.14.0 && driftr pin pnpm@9.15.0
 cd project-b && driftr pin node@24.0.0
 
-# Just use node normally -- Driftr handles the rest
+# Everything just works -- Driftr handles the rest
 cd project-a && node -v   # v22.14.0
+cd project-a && pnpm -v   # 9.15.0
 cd project-b && node -v   # v24.0.0
-cd ~         && node -v   # v24.0.0 (global default)
+cd ~         && node -v   # v22.14.0 (global default)
 ```

--- a/internal/cli/which.go
+++ b/internal/cli/which.go
@@ -17,7 +17,7 @@ func newWhichCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			tool := args[0]
 
-			res, err := resolver.ResolveTool("node", "", verbose)
+			res, err := resolver.ResolveTool(tool, "", verbose)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Summary

Updates all documentation to reflect pnpm, yarn, and toolchain binding support.

### Bug fix
- **which.go:20** — was hardcoded to `resolver.ResolveTool("node", ...)` instead of using the `tool` argument. `driftr which pnpm` now correctly resolves pnpm, not node.

### Documentation updates
- **README.md** — updated tagline, feature list, quick start, commands table, project layout, comparison table ("Planned" → "Yes"), and "when to choose" section
- **docs/usage.md** — added pnpm/yarn examples to every command section, documented three install pipelines, added tool resolution explanation, noted package.json limitation for pnpm/yarn
- **docs/configuration.md** — added multi-tool config examples, updated storage layout, moved pnpm/yarn from "future" to current, added package.json limitation note
- **docs/architecture.md** — updated module map with new files, documented two shim execution modes, added checksum verification table, updated resolution chain
- **docs/installation.md** — updated directory structure with pnpm/yarn shims
- **docs/contributing.md** — updated project structure, refreshed areas for contribution