### PR TITLE
refactor: modernize Go idioms for 1.26

### DIFF
--- a/internal/cli/parse.go
+++ b/internal/cli/parse.go
@@ -5,8 +5,8 @@ import "strings"
 // parseToolVersion splits "node@24.0.0" into ("node", "24.0.0").
 // If no "@" is present, defaults to tool "node".
 func parseToolVersion(spec string) (string, string) {
-	if i := strings.Index(spec, "@"); i >= 0 {
-		return spec[:i], spec[i+1:]
+	if tool, ver, ok := strings.Cut(spec, "@"); ok {
+		return tool, ver
 	}
 	return "node", spec
 }

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -57,7 +58,7 @@ func LoadGlobal() (*GlobalConfig, error) {
 
 	data, err := os.ReadFile(path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return cfg, nil
 		}
 		return nil, fmt.Errorf("failed to read global config: %w", err)

--- a/internal/config/packagejson.go
+++ b/internal/config/packagejson.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -41,7 +42,7 @@ func LoadPackageJSON(dir string) (*PackageJSON, error) {
 
 	data, err := os.ReadFile(path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to read %s: %w", path, err)
@@ -72,7 +73,7 @@ func SavePackageJSONTool(dir, tool, version string) error {
 
 	data, err := os.ReadFile(path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("no package.json found in %s. Run `npm init` first", dir)
 		}
 		return fmt.Errorf("failed to read %s: %w", path, err)
@@ -103,7 +104,7 @@ func RemoveDriftrFromPackageJSON(dir string) error {
 
 	data, err := os.ReadFile(path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return nil
 		}
 		return fmt.Errorf("failed to read %s: %w", path, err)

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -43,7 +44,7 @@ func LoadProject(dir string) (*ProjectConfig, error) {
 
 	data, err := os.ReadFile(path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to read project config: %w", err)

--- a/internal/installer/cleanup_test.go
+++ b/internal/installer/cleanup_test.go
@@ -1,6 +1,7 @@
 package installer
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"sync"
@@ -19,7 +20,7 @@ func TestInstallCleanup_RemovesTmpFile(t *testing.T) {
 	cleanup.setTmpFile(tmpPath)
 	cleanup.run()
 
-	if _, err := os.Stat(tmpPath); !os.IsNotExist(err) {
+	if _, err := os.Stat(tmpPath); !errors.Is(err, os.ErrNotExist) {
 		t.Errorf("temp file should have been removed: %s", tmpPath)
 	}
 }
@@ -42,7 +43,7 @@ func TestInstallCleanup_RemovesVersionDir(t *testing.T) {
 	cleanup := &installCleanup{version: "99.0.0"}
 	cleanup.run()
 
-	if _, err := os.Stat(versionDir); !os.IsNotExist(err) {
+	if _, err := os.Stat(versionDir); !errors.Is(err, os.ErrNotExist) {
 		t.Errorf("version directory should have been removed: %s", versionDir)
 	}
 }
@@ -70,10 +71,10 @@ func TestInstallCleanup_RemovesBothTmpFileAndVersionDir(t *testing.T) {
 	cleanup.setVersion("99.0.0")
 	cleanup.run()
 
-	if _, err := os.Stat(tmpPath); !os.IsNotExist(err) {
+	if _, err := os.Stat(tmpPath); !errors.Is(err, os.ErrNotExist) {
 		t.Errorf("temp file should have been removed")
 	}
-	if _, err := os.Stat(versionDir); !os.IsNotExist(err) {
+	if _, err := os.Stat(versionDir); !errors.Is(err, os.ErrNotExist) {
 		t.Errorf("version directory should have been removed")
 	}
 }
@@ -93,7 +94,7 @@ func TestInstallCleanup_RunIdempotent(t *testing.T) {
 	cleanup.run()
 	cleanup.run()
 
-	if _, err := os.Stat(tmpPath); !os.IsNotExist(err) {
+	if _, err := os.Stat(tmpPath); !errors.Is(err, os.ErrNotExist) {
 		t.Errorf("temp file should have been removed")
 	}
 }
@@ -103,7 +104,7 @@ func TestInstallCleanup_ConcurrentAccess(t *testing.T) {
 
 	var wg sync.WaitGroup
 	// Hammer set/clear/run concurrently to test for races.
-	for i := 0; i < 50; i++ {
+	for range 50 {
 		wg.Add(3)
 		go func() {
 			defer wg.Done()

--- a/internal/installer/extract.go
+++ b/internal/installer/extract.go
@@ -3,6 +3,7 @@ package installer
 import (
 	"archive/tar"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -45,7 +46,7 @@ func extractToRoot(root *os.Root, relPath string, hdr *tar.Header, tr *tar.Reade
 				return fmt.Errorf("failed to create parent dir for %s: %w", relPath, err)
 			}
 		}
-		if err := root.Remove(relPath); err != nil && !os.IsNotExist(err) {
+		if err := root.Remove(relPath); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("failed to remove existing path %s before creating symlink: %w", relPath, err)
 		}
 		if err := root.Symlink(hdr.Linkname, relPath); err != nil {
@@ -111,7 +112,7 @@ func Extract(archivePath, version string, verbose bool) error {
 
 	for {
 		hdr, err := tr.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {
@@ -136,7 +137,7 @@ func Extract(archivePath, version string, verbose bool) error {
 
 	// Verify the node binary exists after extraction.
 	if _, err := root.Stat(filepath.Join("bin", "node")); err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("extraction completed but node binary not found at %s", nodeBin)
 		}
 		return fmt.Errorf("failed to verify extracted node binary at %s: %w", nodeBin, err)

--- a/internal/installer/registry.go
+++ b/internal/installer/registry.go
@@ -1,6 +1,7 @@
 package installer
 
 import (
+	"cmp"
 	"crypto/sha512"
 	"crypto/subtle"
 	"encoding/base64"
@@ -103,7 +104,7 @@ func ResolveRegistryLatest(pkg string, v version.Version) (string, error) {
 		if !v.Matches(rv) {
 			continue
 		}
-		if best == nil || versionGreater(rv, *best) {
+		if best == nil || versionCompare(rv, *best) > 0 {
 			rv := rv // copy
 			best = &rv
 		}
@@ -115,15 +116,15 @@ func ResolveRegistryLatest(pkg string, v version.Version) (string, error) {
 	return best.String(), nil
 }
 
-// versionGreater returns true if a > b in semver ordering.
-func versionGreater(a, b version.Version) bool {
-	if a.Major != b.Major {
-		return a.Major > b.Major
+// versionCompare returns a positive value if a > b, negative if a < b, zero if equal.
+func versionCompare(a, b version.Version) int {
+	if c := cmp.Compare(a.Major, b.Major); c != 0 {
+		return c
 	}
-	if a.Minor != b.Minor {
-		return a.Minor > b.Minor
+	if c := cmp.Compare(a.Minor, b.Minor); c != 0 {
+		return c
 	}
-	return a.Patch > b.Patch
+	return cmp.Compare(a.Patch, b.Patch)
 }
 
 // DownloadRegistryPackage downloads an npm package tarball to the cache directory.

--- a/internal/installer/registry_extract.go
+++ b/internal/installer/registry_extract.go
@@ -3,6 +3,7 @@ package installer
 import (
 	"archive/tar"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -38,7 +39,7 @@ func ExtractRegistryPackage(archivePath, destDir string) error {
 	tr := tar.NewReader(gz)
 	for {
 		hdr, err := tr.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {
@@ -47,8 +48,8 @@ func ExtractRegistryPackage(archivePath, destDir string) error {
 
 		// Strip the "package/" prefix that all npm tarballs use.
 		name := hdr.Name
-		if i := strings.Index(name, "/"); i >= 0 {
-			name = name[i+1:]
+		if _, after, ok := strings.Cut(name, "/"); ok {
+			name = after
 		}
 		if name == "" {
 			continue

--- a/internal/installer/registry_test.go
+++ b/internal/installer/registry_test.go
@@ -99,16 +99,16 @@ func TestVerifyIntegrity_UnsupportedAlgo(t *testing.T) {
 	}
 }
 
-func TestVersionGreater(t *testing.T) {
+func TestVersionCompare(t *testing.T) {
 	tests := []struct {
 		a, b string
-		want bool
+		want int // positive if a > b, negative if a < b, 0 if equal
 	}{
-		{"2.0.0", "1.0.0", true},
-		{"1.1.0", "1.0.0", true},
-		{"1.0.1", "1.0.0", true},
-		{"1.0.0", "1.0.0", false},
-		{"1.0.0", "2.0.0", false},
+		{"2.0.0", "1.0.0", 1},
+		{"1.1.0", "1.0.0", 1},
+		{"1.0.1", "1.0.0", 1},
+		{"1.0.0", "1.0.0", 0},
+		{"1.0.0", "2.0.0", -1},
 	}
 
 	for _, tt := range tests {
@@ -121,8 +121,8 @@ func TestVersionGreater(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Parse(%q) error: %v", tt.b, err)
 			}
-			if got := versionGreater(a, b); got != tt.want {
-				t.Errorf("versionGreater(%s, %s) = %v, want %v", tt.a, tt.b, got, tt.want)
+			if got := versionCompare(a, b); got != tt.want {
+				t.Errorf("versionCompare(%s, %s) = %v, want %v", tt.a, tt.b, got, tt.want)
 			}
 		})
 	}

--- a/internal/installer/yarn.go
+++ b/internal/installer/yarn.go
@@ -1,6 +1,7 @@
 package installer
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -76,7 +77,7 @@ func InstallYarn(versionStr string, verbose bool) (string, error) {
 	}
 
 	// Verify the binary exists after extraction.
-	if _, err := os.Stat(binPath); os.IsNotExist(err) {
+	if _, err := os.Stat(binPath); errors.Is(err, os.ErrNotExist) {
 		os.RemoveAll(versionDir)
 		return "", fmt.Errorf("yarn binary not found after extraction at %s", binPath)
 	}

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -1,6 +1,7 @@
 package platform
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -185,7 +186,7 @@ func ListToolVersions(tool string) ([]string, error) {
 	toolDir := filepath.Join(toolsDir, tool)
 	entries, err := os.ReadDir(toolDir)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to read %s versions: %w", tool, err)

--- a/internal/platform/platform_test.go
+++ b/internal/platform/platform_test.go
@@ -1,6 +1,7 @@
 package platform
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -144,7 +145,7 @@ func TestEnsureToolDirs(t *testing.T) {
 		filepath.Join(home, ".driftr", "tools", "node"),
 		filepath.Join(home, ".driftr", "tools", "pnpm"),
 	} {
-		if _, err := os.Stat(dir); os.IsNotExist(err) {
+		if _, err := os.Stat(dir); errors.Is(err, os.ErrNotExist) {
 			t.Errorf("expected directory %s to exist", dir)
 		}
 	}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -1,10 +1,12 @@
 package resolver
 
 import (
+	"cmp"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 
 	"github.com/DriftrLabs/driftr/internal/config"
 	"github.com/DriftrLabs/driftr/internal/platform"
@@ -63,14 +65,14 @@ func resolveInstalledPartial(tool string, v version.Version) (string, string, er
 	}
 
 	// Sort descending to pick the latest.
-	sort.Slice(matches, func(i, j int) bool {
-		if matches[i].Major != matches[j].Major {
-			return matches[i].Major > matches[j].Major
+	slices.SortFunc(matches, func(a, b version.Version) int {
+		if c := cmp.Compare(b.Major, a.Major); c != 0 {
+			return c
 		}
-		if matches[i].Minor != matches[j].Minor {
-			return matches[i].Minor > matches[j].Minor
+		if c := cmp.Compare(b.Minor, a.Minor); c != 0 {
+			return c
 		}
-		return matches[i].Patch > matches[j].Patch
+		return cmp.Compare(b.Patch, a.Patch)
 	})
 
 	best := matches[0].String()
@@ -92,7 +94,7 @@ func requireToolBinaryExists(tool, ver, context string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if _, err := os.Stat(binPath); os.IsNotExist(err) {
+	if _, err := os.Stat(binPath); errors.Is(err, os.ErrNotExist) {
 		if context != "" {
 			return "", fmt.Errorf("%s %s (%s) is not installed. Run `driftr install %s@%s`", tool, ver, context, tool, ver)
 		}

--- a/internal/shim/shim_test.go
+++ b/internal/shim/shim_test.go
@@ -1,6 +1,7 @@
 package shim
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -52,7 +53,7 @@ func TestWriteShim_AllTools(t *testing.T) {
 		if err := writeShim(dir, tool, "/bin/driftr"); err != nil {
 			t.Fatalf("writeShim(%q) error: %v", tool, err)
 		}
-		if _, err := os.Stat(filepath.Join(dir, tool)); os.IsNotExist(err) {
+		if _, err := os.Stat(filepath.Join(dir, tool)); errors.Is(err, os.ErrNotExist) {
 			t.Errorf("shim for %q was not created", tool)
 		}
 	}

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -204,7 +205,7 @@ func extractBinary(archivePath, destPath string) error {
 	tr := tar.NewReader(gz)
 	for {
 		hdr, err := tr.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -17,8 +17,8 @@ type Version struct {
 
 // stripToolPrefix removes an optional "tool@" prefix (e.g. "node@24" → "24").
 func stripToolPrefix(s string) string {
-	if i := strings.Index(s, "@"); i >= 0 {
-		return s[i+1:]
+	if _, after, ok := strings.Cut(s, "@"); ok {
+		return after
 	}
 	return s
 }


### PR DESCRIPTION
## Summary
- Replace `os.IsNotExist()` with `errors.Is(err, os.ErrNotExist)` across 10 files (17 instances) — correctly handles wrapped errors
- Replace `err == io.EOF` with `errors.Is(err, io.EOF)` in 3 files — same reasoning
- Replace `sort.Slice` with `slices.SortFunc` + `cmp.Compare` in resolver — type-safe, no index juggling
- Replace `versionGreater()` bool helper with `versionCompare()` int using `cmp.Compare` in registry
- Replace `strings.Index` + manual slicing with `strings.Cut` in 3 files — cleaner split pattern
- Replace C-style `for i := 0; i < 50; i++` with `for range 50` in test