### PR TITLE
feat: add driftr cache clean and cache dir commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ pnpm -v   # resolves automatically
 | `driftr which <tool>` | Show which binary would be executed and why |
 | `driftr run --node <ver> -- <cmd>` | Run a command under a specific Node.js version |
 | `driftr setup` | Initialize Driftr and generate shims |
+| `driftr cache clean` | Remove all cached downloads to free disk space |
+| `driftr cache dir` | Print the cache directory path |
 | `driftr self-update` | Update Driftr to the latest version |
 
 All commands support `-v` / `--verbose` for detailed output including resolver tracing and checksum details.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -227,6 +227,24 @@ driftr setup
 
 Run this once after installing Driftr, and again after upgrading to regenerate shims.
 
+## driftr cache
+
+Manage the download cache.
+
+```bash
+# Remove all cached archives to free disk space
+driftr cache clean
+
+# Print the cache directory path
+driftr cache dir
+```
+
+**Notes:**
+
+- `driftr cache clean` removes all files from `~/.driftr/cache/` and reports the freed space
+- Installed tool versions are not affected — only cached downloads are removed
+- Cached archives are automatically reused by `driftr install` to skip re-downloads
+
 ## Resolution Order
 
 When you run a tool (`node`, `npm`, `npx`, `pnpm`, `pnpx`, or `yarn`), Driftr resolves the version in this order:

--- a/internal/cli/cache.go
+++ b/internal/cli/cache.go
@@ -1,0 +1,99 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/DriftrLabs/driftr/internal/platform"
+)
+
+func newCacheCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cache",
+		Short: "Manage the download cache",
+	}
+
+	cmd.AddCommand(newCacheCleanCmd())
+	cmd.AddCommand(newCacheDirCmd())
+
+	return cmd
+}
+
+func newCacheCleanCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "clean",
+		Short: "Remove all cached downloads",
+		Long:  "Delete all cached archives and binaries from ~/.driftr/cache/.\nInstalled tool versions are not affected.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cacheDir, err := platform.CacheDir()
+			if err != nil {
+				return err
+			}
+
+			entries, err := os.ReadDir(cacheDir)
+			if err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					fmt.Println("Cache is already empty.")
+					return nil
+				}
+				return fmt.Errorf("failed to read cache directory: %w", err)
+			}
+
+			if len(entries) == 0 {
+				fmt.Println("Cache is already empty.")
+				return nil
+			}
+
+			var totalSize int64
+			for _, entry := range entries {
+				info, err := entry.Info()
+				if err != nil {
+					continue
+				}
+				totalSize += info.Size()
+			}
+
+			if err := os.RemoveAll(cacheDir); err != nil {
+				return fmt.Errorf("failed to clean cache: %w", err)
+			}
+
+			fmt.Printf("Removed %d cached file(s), freed %s.\n", len(entries), formatSize(totalSize))
+			return nil
+		},
+	}
+}
+
+func newCacheDirCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "dir",
+		Short: "Print the cache directory path",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cacheDir, err := platform.CacheDir()
+			if err != nil {
+				return err
+			}
+			fmt.Println(cacheDir)
+			return nil
+		},
+	}
+}
+
+func formatSize(bytes int64) string {
+	const (
+		mb = 1024 * 1024
+		kb = 1024
+	)
+	switch {
+	case bytes >= mb:
+		return fmt.Sprintf("%.1f MB", float64(bytes)/float64(mb))
+	case bytes >= kb:
+		return fmt.Sprintf("%.1f KB", float64(bytes)/float64(kb))
+	default:
+		return fmt.Sprintf("%d B", bytes)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -49,6 +49,7 @@ func NewRootCmd() *cobra.Command {
 		newRunCmd(),
 		newShimCmd(),
 		newSetupCmd(),
+		newCacheCmd(),
 		newUpdateCmd(),
 	)
 


### PR DESCRIPTION
## Summary
- Add `driftr cache clean` to remove all cached archives and report freed disk space
- Add `driftr cache dir` to print the cache directory path
- Handles empty/missing cache directory gracefully
- Updates README command table and docs/usage.md

## Test plan
- [x] `go build` compiles
- [x] `go vet` passes
- [x] `go test ./...` passes
- [ ] CI passes
- [ ] Manual: `driftr cache dir` prints `~/.driftr/cache`
- [ ] Manual: `driftr cache clean` on populated cache reports file count and freed space
- [ ] Manual: `driftr cache clean` on empty/missing cache prints "Cache is already empty."