### PR TITLE
feat: auto-install prompt when pinned version is not installed

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,6 +11,8 @@ This file stores your global default tool versions. It is created and managed by
 ### Format
 
 ```toml
+auto_install = true  # install missing versions without prompting
+
 [default]
 node = "22.14.0"
 
@@ -21,11 +23,12 @@ yarn = "1.22.22"
 
 ### Fields
 
-| Section           | Key    | Type   | Description                     |
-|-------------------|--------|--------|---------------------------------|
-| `[default]`       | `node` | string | Global default Node.js version  |
-| `[default.tools]` | `pnpm` | string | Global default pnpm version     |
-| `[default.tools]` | `yarn` | string | Global default yarn version     |
+| Section           | Key            | Type   | Description                                             |
+|-------------------|----------------|--------|---------------------------------------------------------|
+| (top-level)       | `auto_install` | bool   | Automatically install missing versions (default: false) |
+| `[default]`       | `node`         | string | Global default Node.js version                          |
+| `[default.tools]` | `pnpm`         | string | Global default pnpm version                             |
+| `[default.tools]` | `yarn`         | string | Global default yarn version                             |
 
 ### Example
 

--- a/internal/cli/shim_cmd.go
+++ b/internal/cli/shim_cmd.go
@@ -69,7 +69,7 @@ func handleNotInstalled(err error, tool string) (*resolver.ResolvedBinary, error
 	}
 
 	if !promptInstall(notInstalled) {
-		return nil, fmt.Errorf("%s %s is not installed", notInstalled.Tool, notInstalled.Version)
+		os.Exit(1)
 	}
 
 	return autoInstall(notInstalled, tool)

--- a/internal/cli/shim_cmd.go
+++ b/internal/cli/shim_cmd.go
@@ -1,10 +1,16 @@
 package cli
 
 import (
+	"bufio"
+	"errors"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
+	"github.com/DriftrLabs/driftr/internal/config"
+	"github.com/DriftrLabs/driftr/internal/ioutil"
 	"github.com/DriftrLabs/driftr/internal/process"
 	"github.com/DriftrLabs/driftr/internal/resolver"
 )
@@ -25,7 +31,10 @@ func newShimCmd() *cobra.Command {
 
 			rb, err := resolver.ResolveBinaryFull(tool, "")
 			if err != nil {
-				return fmt.Errorf("error: %w", err)
+				rb, err = handleNotInstalled(err, tool)
+				if err != nil {
+					return fmt.Errorf("error: %w", err)
+				}
 			}
 
 			// For tools that need Node.js (e.g. yarn), exec node with the tool script.
@@ -38,4 +47,48 @@ func newShimCmd() *cobra.Command {
 			return process.Exec(rb.ToolPath, toolArgs)
 		},
 	}
+}
+
+// handleNotInstalled checks if the error is a NotInstalledError and offers to install.
+// Returns the resolved binary on successful install, or the original error.
+func handleNotInstalled(err error, tool string) (*resolver.ResolvedBinary, error) {
+	var notInstalled *resolver.NotInstalledError
+	if !errors.As(err, &notInstalled) {
+		return nil, err
+	}
+
+	if !shouldAutoInstall(notInstalled) {
+		return nil, fmt.Errorf("%s %s is not installed", notInstalled.Tool, notInstalled.Version)
+	}
+
+	fmt.Fprintf(os.Stderr, "Installing %s@%s...\n", notInstalled.Tool, notInstalled.Version)
+	if _, installErr := installTool(notInstalled.Tool, notInstalled.Version, false); installErr != nil {
+		return nil, fmt.Errorf("auto-install failed: %w", installErr)
+	}
+	fmt.Fprintf(os.Stderr, "Installed %s %s\n", notInstalled.Tool, notInstalled.Version)
+
+	// Retry resolution after install.
+	return resolver.ResolveBinaryFull(tool, "")
+}
+
+// shouldAutoInstall decides whether to install a missing version.
+// Returns true if auto_install is enabled in config, or the user confirms at an interactive prompt.
+func shouldAutoInstall(e *resolver.NotInstalledError) bool {
+	cfg, err := config.LoadGlobal()
+	if err == nil && cfg.AutoInstall {
+		return true
+	}
+
+	if !ioutil.IsTerminal(os.Stdin) {
+		return false
+	}
+
+	fmt.Fprintf(os.Stderr, "%s\nInstall now? [Y/n] ", e.Error())
+	reader := bufio.NewReader(os.Stdin)
+	answer, err := reader.ReadString('\n')
+	if err != nil {
+		return false
+	}
+	answer = strings.TrimSpace(strings.ToLower(answer))
+	return answer == "" || answer == "y" || answer == "yes"
 }

--- a/internal/cli/shim_cmd.go
+++ b/internal/cli/shim_cmd.go
@@ -57,33 +57,43 @@ func handleNotInstalled(err error, tool string) (*resolver.ResolvedBinary, error
 		return nil, err
 	}
 
-	if !shouldAutoInstall(notInstalled) {
+	// Auto-install if configured.
+	cfg, cfgErr := config.LoadGlobal()
+	if cfgErr == nil && cfg.AutoInstall {
+		return autoInstall(notInstalled, tool)
+	}
+
+	// Prompt only in interactive terminals.
+	if !ioutil.IsTerminal(os.Stdin) {
+		return nil, err
+	}
+
+	if !promptInstall(notInstalled) {
 		return nil, fmt.Errorf("%s %s is not installed", notInstalled.Tool, notInstalled.Version)
 	}
 
-	fmt.Fprintf(os.Stderr, "Installing %s@%s...\n", notInstalled.Tool, notInstalled.Version)
-	if _, installErr := installTool(notInstalled.Tool, notInstalled.Version, false); installErr != nil {
-		return nil, fmt.Errorf("auto-install failed: %w", installErr)
+	return autoInstall(notInstalled, tool)
+}
+
+func autoInstall(e *resolver.NotInstalledError, tool string) (*resolver.ResolvedBinary, error) {
+	fmt.Fprintf(os.Stderr, "Installing %s@%s...\n", e.Tool, e.Version)
+	if _, err := installTool(e.Tool, e.Version, false); err != nil {
+		return nil, fmt.Errorf("auto-install failed: %w", err)
 	}
-	fmt.Fprintf(os.Stderr, "Installed %s %s\n", notInstalled.Tool, notInstalled.Version)
+	fmt.Fprintf(os.Stderr, "Installed %s %s\n", e.Tool, e.Version)
 
 	// Retry resolution after install.
 	return resolver.ResolveBinaryFull(tool, "")
 }
 
-// shouldAutoInstall decides whether to install a missing version.
-// Returns true if auto_install is enabled in config, or the user confirms at an interactive prompt.
-func shouldAutoInstall(e *resolver.NotInstalledError) bool {
-	cfg, err := config.LoadGlobal()
-	if err == nil && cfg.AutoInstall {
-		return true
+// promptInstall asks the user whether to install a missing version.
+func promptInstall(e *resolver.NotInstalledError) bool {
+	msg := fmt.Sprintf("%s %s is not installed", e.Tool, e.Version)
+	if e.Context != "" {
+		msg = fmt.Sprintf("%s %s (%s) is not installed", e.Tool, e.Version, e.Context)
 	}
+	fmt.Fprintf(os.Stderr, "%s\nInstall now? [Y/n] ", msg)
 
-	if !ioutil.IsTerminal(os.Stdin) {
-		return false
-	}
-
-	fmt.Fprintf(os.Stderr, "%s\nInstall now? [Y/n] ", e.Error())
 	reader := bufio.NewReader(os.Stdin)
 	answer, err := reader.ReadString('\n')
 	if err != nil {

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -14,6 +14,7 @@ import (
 // GlobalConfig represents ~/.driftr/config/config.toml
 type GlobalConfig struct {
 	Default DefaultConfig `toml:"default"`
+	AutoInstall bool      `toml:"auto_install,omitempty"` // install missing versions without prompting
 }
 
 // DefaultConfig holds the default tool versions.

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -13,8 +13,8 @@ import (
 
 // GlobalConfig represents ~/.driftr/config/config.toml
 type GlobalConfig struct {
-	Default DefaultConfig `toml:"default"`
-	AutoInstall bool      `toml:"auto_install,omitempty"` // install missing versions without prompting
+	Default     DefaultConfig `toml:"default"`
+	AutoInstall bool          `toml:"auto_install,omitempty"` // install missing versions without prompting
 }
 
 // DefaultConfig holds the default tool versions.

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -39,6 +39,33 @@ func TestSaveAndLoadGlobal(t *testing.T) {
 	}
 }
 
+func TestSaveAndLoadGlobal_AutoInstall(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	if err := platform.EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs() error: %v", err)
+	}
+
+	cfg := &GlobalConfig{
+		Default:     DefaultConfig{Node: "22.14.0"},
+		AutoInstall: true,
+	}
+	if err := SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal() error: %v", err)
+	}
+
+	loaded, err := LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal() error: %v", err)
+	}
+	if !loaded.AutoInstall {
+		t.Error("AutoInstall should be true after round-trip")
+	}
+	if loaded.Default.Node != "22.14.0" {
+		t.Errorf("Default.Node = %q, want %q", loaded.Default.Node, "22.14.0")
+	}
+}
+
 func TestSaveGlobal_OverwritesExisting(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -88,6 +88,20 @@ func ListToolVersions(tool string) ([]string, error) {
 	return platform.ListToolVersions(tool)
 }
 
+// NotInstalledError is returned when a resolved tool version is not installed locally.
+type NotInstalledError struct {
+	Tool    string
+	Version string
+	Context string // e.g. "pinned in /home/user/project" or "global default"
+}
+
+func (e *NotInstalledError) Error() string {
+	if e.Context != "" {
+		return fmt.Sprintf("%s %s (%s) is not installed. Run `driftr install %s@%s`", e.Tool, e.Version, e.Context, e.Tool, e.Version)
+	}
+	return fmt.Sprintf("%s %s is not installed. Run `driftr install %s@%s`", e.Tool, e.Version, e.Tool, e.Version)
+}
+
 // requireToolBinaryExists checks that the binary for the given tool and version is installed.
 func requireToolBinaryExists(tool, ver, context string) (string, error) {
 	binPath, err := platform.ToolBinary(tool, ver)
@@ -95,10 +109,7 @@ func requireToolBinaryExists(tool, ver, context string) (string, error) {
 		return "", err
 	}
 	if _, err := os.Stat(binPath); errors.Is(err, os.ErrNotExist) {
-		if context != "" {
-			return "", fmt.Errorf("%s %s (%s) is not installed. Run `driftr install %s@%s`", tool, ver, context, tool, ver)
-		}
-		return "", fmt.Errorf("%s %s is not installed. Run `driftr install %s@%s`", tool, ver, tool, ver)
+		return "", &NotInstalledError{Tool: tool, Version: ver, Context: context}
 	}
 	return binPath, nil
 }

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -108,8 +108,11 @@ func requireToolBinaryExists(tool, ver, context string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if _, err := os.Stat(binPath); errors.Is(err, os.ErrNotExist) {
-		return "", &NotInstalledError{Tool: tool, Version: ver, Context: context}
+	if _, err := os.Stat(binPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", &NotInstalledError{Tool: tool, Version: ver, Context: context}
+		}
+		return "", fmt.Errorf("failed to check %s %s binary: %w", tool, ver, err)
 	}
 	return binPath, nil
 }

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -1,8 +1,11 @@
 package resolver
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/DriftrLabs/driftr/internal/config"
@@ -318,6 +321,58 @@ func TestSourceString(t *testing.T) {
 		if got := tt.source.String(); got != tt.want {
 			t.Errorf("Source(%d).String() = %q, want %q", tt.source, got, tt.want)
 		}
+	}
+}
+
+func TestNotInstalledError(t *testing.T) {
+	e := &NotInstalledError{Tool: "node", Version: "24.1.0", Context: "pinned in /home/user/project"}
+	msg := e.Error()
+	if !strings.Contains(msg, "node 24.1.0") {
+		t.Errorf("error should contain tool and version, got: %s", msg)
+	}
+	if !strings.Contains(msg, "pinned in /home/user/project") {
+		t.Errorf("error should contain context, got: %s", msg)
+	}
+	if !strings.Contains(msg, "driftr install node@24.1.0") {
+		t.Errorf("error should contain install hint, got: %s", msg)
+	}
+
+	// Without context.
+	e2 := &NotInstalledError{Tool: "pnpm", Version: "9.0.0"}
+	msg2 := e2.Error()
+	if strings.Contains(msg2, "(") {
+		t.Errorf("error without context should not contain parens, got: %s", msg2)
+	}
+}
+
+func TestNotInstalledError_ErrorsAs(t *testing.T) {
+	orig := &NotInstalledError{Tool: "node", Version: "22.0.0"}
+	wrapped := fmt.Errorf("resolution failed: %w", orig)
+
+	var target *NotInstalledError
+	if !errors.As(wrapped, &target) {
+		t.Fatal("errors.As should unwrap NotInstalledError from wrapped error")
+	}
+	if target.Tool != "node" || target.Version != "22.0.0" {
+		t.Errorf("unwrapped error has wrong fields: %+v", target)
+	}
+}
+
+func TestRequireToolBinaryExists_NotInstalled(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	_, err := requireToolBinaryExists("node", "99.99.99", "global default")
+	if err == nil {
+		t.Fatal("expected error for non-existent version")
+	}
+
+	var notInstalled *NotInstalledError
+	if !errors.As(err, &notInstalled) {
+		t.Fatalf("expected NotInstalledError, got %T: %v", err, err)
+	}
+	if notInstalled.Tool != "node" || notInstalled.Version != "99.99.99" || notInstalled.Context != "global default" {
+		t.Errorf("unexpected fields: %+v", notInstalled)
 	}
 }
 


### PR DESCRIPTION
## Summary
When a shim resolves a version that isn't installed, driftr now offers to install it on the spot instead of just printing an error with a manual command.

**Behavior:**
- **Interactive terminal**: prompts `Install now? [Y/n]` — enter or `y` installs, `n` exits cleanly
- **Non-interactive** (CI, pipes, scripts): falls through to the existing error — never blocks
- **`auto_install = true`** in `~/.driftr/config/config.toml`: installs automatically without prompting

**Implementation:**
- New `NotInstalledError` type in resolver for structured error detection via `errors.As`
- Shim command intercepts the error, prompts/auto-installs, then retries resolution
- Stdin read errors are handled safely (treated as decline, not as confirmation)
- After user declines, error message omits the redundant "Run `driftr install`" hint

Closes #47

## Test plan
- [x] `go build` compiles
- [x] `go vet` passes
- [x] `go test ./...` passes
- [x] CI passes
- [x] Manual: run shimmed tool with missing pinned version in a terminal — prompt appears
- [x] Manual: pipe into shimmed tool (`echo test | node`) — no prompt, clean error
- [x] Manual: set `auto_install = true` in config — installs without prompting