### PR TITLE
fix: wire auto-install prompt into shim fast path

### DIFF
--- a/cmd/driftr/main.go
+++ b/cmd/driftr/main.go
@@ -28,6 +28,7 @@ func main() {
 				fmt.Fprintf(os.Stderr, "driftr: %s\n", err)
 				os.Exit(1)
 			}
+			return
 		}
 		if err := process.Exec(rb.ToolPath, os.Args[3:]); err != nil {
 			fmt.Fprintf(os.Stderr, "driftr: %s\n", err)

--- a/cmd/driftr/main.go
+++ b/cmd/driftr/main.go
@@ -14,12 +14,22 @@ func main() {
 	// Shim scripts call "driftr shim <tool> [args...]".
 	if len(os.Args) >= 3 && os.Args[1] == "shim" {
 		tool := os.Args[2]
-		binPath, err := resolver.ResolveBinary(tool, "")
+		rb, err := resolver.ResolveBinaryFull(tool, "")
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "driftr: %s\n", err)
-			os.Exit(1)
+			rb, err = cli.HandleShimError(err, tool)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "driftr: %s\n", err)
+				os.Exit(1)
+			}
 		}
-		if err := process.Exec(binPath, os.Args[3:]); err != nil {
+		if rb.NodePath != "" {
+			nodeArgs := append([]string{rb.ToolPath}, os.Args[3:]...)
+			if err := process.Exec(rb.NodePath, nodeArgs); err != nil {
+				fmt.Fprintf(os.Stderr, "driftr: %s\n", err)
+				os.Exit(1)
+			}
+		}
+		if err := process.Exec(rb.ToolPath, os.Args[3:]); err != nil {
 			fmt.Fprintf(os.Stderr, "driftr: %s\n", err)
 			os.Exit(1)
 		}

--- a/internal/cli/shim_cmd.go
+++ b/internal/cli/shim_cmd.go
@@ -31,7 +31,7 @@ func newShimCmd() *cobra.Command {
 
 			rb, err := resolver.ResolveBinaryFull(tool, "")
 			if err != nil {
-				rb, err = handleNotInstalled(err, tool)
+				rb, err = HandleShimError(err, tool)
 				if err != nil {
 					return fmt.Errorf("error: %w", err)
 				}
@@ -49,9 +49,10 @@ func newShimCmd() *cobra.Command {
 	}
 }
 
-// handleNotInstalled checks if the error is a NotInstalledError and offers to install.
+// HandleShimError checks if the error is a NotInstalledError and offers to install.
 // Returns the resolved binary on successful install, or the original error.
-func handleNotInstalled(err error, tool string) (*resolver.ResolvedBinary, error) {
+// Called from the fast path in main.go and from the cobra shim command.
+func HandleShimError(err error, tool string) (*resolver.ResolvedBinary, error) {
 	var notInstalled *resolver.NotInstalledError
 	if !errors.As(err, &notInstalled) {
 		return nil, err


### PR DESCRIPTION
## Summary

The auto-install prompt from #49 was never reached during normal shim usage. `main.go` has a performance fast path that bypasses cobra entirely for `driftr shim <tool>` invocations — it called `resolver.ResolveBinary()` directly and printed errors to stderr without ever reaching `shim_cmd.go`.

**Changes:**

- Fast path now calls `ResolveBinaryFull` (supports `NeedsNode` tools like pnpm/yarn)
- On resolution failure, calls `cli.HandleShimError()` to trigger auto-install prompt or config-based auto-install
- Exports `HandleShimError` so both the fast path and cobra fallback share the same logic

## Test plan

- [x] `go build` compiles
- [x] `go vet` passes
- [x] `go test ./...` passes
- [x] CI passes
- [ ] Manual: `node -v` in a project with a missing pinned version shows install prompt in a terminal
- [ ] Manual: non-interactive context (piped stdin) shows the existing error message