### PR TITLE
feat: add driftr doctor command

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -28,7 +28,10 @@ func newDoctorCmd() *cobra.Command {
 		Short: "Check your driftr installation for problems",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			binDir, _ := platform.BinDir()
+			binDir, err := platform.BinDir()
+			if err != nil {
+				return fmt.Errorf("cannot determine driftr bin directory: %w", err)
+			}
 			cfg, cfgErr := config.LoadGlobal()
 
 			toolVersions := make(map[string][]string)
@@ -69,13 +72,9 @@ func warn(msg string) {
 }
 
 func checkPath(binDir string) int {
-	if binDir == "" {
-		warn("Cannot determine bin directory")
-		return 1
-	}
-
+	cleanBinDir := filepath.Clean(binDir)
 	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
-		if dir == binDir {
+		if filepath.Clean(dir) == cleanBinDir {
 			pass(binDir + " is on PATH")
 			return 0
 		}
@@ -86,12 +85,8 @@ func checkPath(binDir string) int {
 }
 
 func checkShims(binDir string) int {
-	if binDir == "" {
-		return 0
-	}
-
 	missing := 0
-	for _, tool := range shim.ShimTools {
+	for _, tool := range shim.ShimTools() {
 		shimPath := filepath.Join(binDir, tool)
 		info, err := os.Stat(shimPath)
 		if err != nil {
@@ -106,16 +101,12 @@ func checkShims(binDir string) int {
 	}
 
 	if missing == 0 {
-		pass(fmt.Sprintf("All %d shims installed", len(shim.ShimTools)))
+		pass(fmt.Sprintf("All %d shims installed", len(shim.ShimTools())))
 	}
 	return missing
 }
 
 func checkShimBinaryPath(binDir string) int {
-	if binDir == "" {
-		return 0
-	}
-
 	currentBin, err := os.Executable()
 	if err != nil {
 		return 0
@@ -207,7 +198,7 @@ func checkConflictingManagers(binDir string) int {
 		if err != nil {
 			continue
 		}
-		if binDir != "" && filepath.Dir(path) == binDir {
+		if filepath.Dir(path) == binDir {
 			continue
 		}
 		warn(fmt.Sprintf("%s detected at %s — may conflict with driftr shims", manager, path))

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -35,14 +35,17 @@ func newDoctorCmd() *cobra.Command {
 			cfg, cfgErr := config.LoadGlobal()
 
 			toolVersions := make(map[string][]string)
+			issues := 0
 			for _, tool := range versionedTools {
 				versions, err := platform.ListToolVersions(tool)
-				if err == nil {
-					toolVersions[tool] = versions
+				if err != nil {
+					warn(fmt.Sprintf("Cannot list installed versions for %s: %s", tool, err))
+					issues++
+					continue
 				}
+				toolVersions[tool] = versions
 			}
 
-			issues := 0
 			issues += checkPath(binDir)
 			issues += checkShims(binDir)
 			issues += checkShimBinaryPath(binDir)

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -11,12 +11,16 @@ import (
 
 	"github.com/DriftrLabs/driftr/internal/config"
 	"github.com/DriftrLabs/driftr/internal/platform"
+	"github.com/DriftrLabs/driftr/internal/shim"
 )
 
-var shimTools = []string{"node", "npm", "npx", "pnpm", "pnpx", "yarn"}
+// versionedTools are tools that have independently installed versions.
+var versionedTools = []string{"node", "pnpm", "yarn"}
 
 // conflicting node version managers to detect on PATH.
-var conflictingManagers = []string{"nvm", "fnm", "volta", "n"}
+var conflictingBinaries = []string{"fnm", "volta", "n"}
+
+const shimExecPrefix = `exec "`
 
 func newDoctorCmd() *cobra.Command {
 	return &cobra.Command{
@@ -24,15 +28,26 @@ func newDoctorCmd() *cobra.Command {
 		Short: "Check your driftr installation for problems",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			binDir, _ := platform.BinDir()
+			cfg, cfgErr := config.LoadGlobal()
+
+			toolVersions := make(map[string][]string)
+			for _, tool := range versionedTools {
+				versions, err := platform.ListToolVersions(tool)
+				if err == nil {
+					toolVersions[tool] = versions
+				}
+			}
+
 			issues := 0
-			issues += checkPath()
-			issues += checkShims()
-			issues += checkShimBinaryPath()
-			issues += checkGlobalDefault()
-			issues += checkDefaultsInstalled()
-			issues += checkConflictingManagers()
-			issues += checkInstalledVersions()
-			issues += checkNeedsNode()
+			issues += checkPath(binDir)
+			issues += checkShims(binDir)
+			issues += checkShimBinaryPath(binDir)
+			issues += checkGlobalDefault(cfg, cfgErr)
+			issues += checkDefaultsInstalled(cfg)
+			issues += checkConflictingManagers(binDir)
+			issues += checkInstalledVersions(toolVersions)
+			issues += checkNeedsNode(toolVersions)
 
 			fmt.Println()
 			if issues == 0 {
@@ -53,15 +68,13 @@ func warn(msg string) {
 	fmt.Printf("  !!  %s\n", msg)
 }
 
-func checkPath() int {
-	binDir, err := platform.BinDir()
-	if err != nil {
+func checkPath(binDir string) int {
+	if binDir == "" {
 		warn("Cannot determine bin directory")
 		return 1
 	}
 
-	pathDirs := filepath.SplitList(os.Getenv("PATH"))
-	for _, dir := range pathDirs {
+	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
 		if dir == binDir {
 			pass(binDir + " is on PATH")
 			return 0
@@ -72,15 +85,13 @@ func checkPath() int {
 	return 1
 }
 
-func checkShims() int {
-	binDir, err := platform.BinDir()
-	if err != nil {
-		warn("Cannot determine bin directory")
-		return 1
+func checkShims(binDir string) int {
+	if binDir == "" {
+		return 0
 	}
 
 	missing := 0
-	for _, tool := range shimTools {
+	for _, tool := range shim.ShimTools {
 		shimPath := filepath.Join(binDir, tool)
 		info, err := os.Stat(shimPath)
 		if err != nil {
@@ -95,14 +106,13 @@ func checkShims() int {
 	}
 
 	if missing == 0 {
-		pass(fmt.Sprintf("All %d shims installed", len(shimTools)))
+		pass(fmt.Sprintf("All %d shims installed", len(shim.ShimTools)))
 	}
 	return missing
 }
 
-func checkShimBinaryPath() int {
-	binDir, err := platform.BinDir()
-	if err != nil {
+func checkShimBinaryPath(binDir string) int {
+	if binDir == "" {
 		return 0
 	}
 
@@ -112,7 +122,6 @@ func checkShimBinaryPath() int {
 	}
 	currentBin, _ = filepath.EvalSymlinks(currentBin)
 
-	// Check the first shim to see where it points.
 	shimPath := filepath.Join(binDir, "node")
 	data, err := os.ReadFile(shimPath)
 	if err != nil {
@@ -120,9 +129,8 @@ func checkShimBinaryPath() int {
 	}
 
 	content := string(data)
-	// Extract the binary path from: exec "/path/to/driftr" shim node "$@"
-	if idx := strings.Index(content, "exec \""); idx >= 0 {
-		rest := content[idx+6:]
+	if idx := strings.Index(content, shimExecPrefix); idx >= 0 {
+		rest := content[idx+len(shimExecPrefix):]
 		if end := strings.Index(rest, "\""); end >= 0 {
 			shimBin := rest[:end]
 			resolved, _ := filepath.EvalSymlinks(shimBin)
@@ -141,10 +149,9 @@ func checkShimBinaryPath() int {
 	return 0
 }
 
-func checkGlobalDefault() int {
-	cfg, err := config.LoadGlobal()
-	if err != nil {
-		warn(fmt.Sprintf("Cannot read global config: %s", err))
+func checkGlobalDefault(cfg *config.GlobalConfig, cfgErr error) int {
+	if cfgErr != nil {
+		warn(fmt.Sprintf("Cannot read global config: %s", cfgErr))
 		return 1
 	}
 
@@ -157,14 +164,13 @@ func checkGlobalDefault() int {
 	return 0
 }
 
-func checkDefaultsInstalled() int {
-	cfg, err := config.LoadGlobal()
-	if err != nil {
-		return 0 // already reported by checkGlobalDefault
+func checkDefaultsInstalled(cfg *config.GlobalConfig) int {
+	if cfg == nil {
+		return 0
 	}
 
 	issues := 0
-	for _, tool := range []string{"node", "pnpm", "yarn"} {
+	for _, tool := range versionedTools {
 		ver := cfg.Default.GetTool(tool)
 		if ver == "" {
 			continue
@@ -185,20 +191,23 @@ func checkDefaultsInstalled() int {
 	return issues
 }
 
-func checkConflictingManagers() int {
-	binDir, err := platform.BinDir()
-	if err != nil {
-		return 0
+func checkConflictingManagers(binDir string) int {
+	issues := 0
+
+	// nvm is a shell function, not a binary — check $NVM_DIR instead.
+	if nvmDir := os.Getenv("NVM_DIR"); nvmDir != "" {
+		if _, err := os.Stat(filepath.Join(nvmDir, "nvm.sh")); err == nil {
+			warn(fmt.Sprintf("nvm detected ($NVM_DIR=%s) — may conflict with driftr shims", nvmDir))
+			issues++
+		}
 	}
 
-	issues := 0
-	for _, manager := range conflictingManagers {
+	for _, manager := range conflictingBinaries {
 		path, err := exec.LookPath(manager)
 		if err != nil {
 			continue
 		}
-		// Ignore if it's our own shim directory.
-		if filepath.Dir(path) == binDir {
+		if binDir != "" && filepath.Dir(path) == binDir {
 			continue
 		}
 		warn(fmt.Sprintf("%s detected at %s — may conflict with driftr shims", manager, path))
@@ -211,31 +220,26 @@ func checkConflictingManagers() int {
 	return issues
 }
 
-func checkInstalledVersions() int {
-	for _, tool := range []string{"node", "pnpm", "yarn"} {
-		versions, err := platform.ListToolVersions(tool)
-		if err != nil || len(versions) == 0 {
-			continue
+func checkInstalledVersions(toolVersions map[string][]string) int {
+	for _, tool := range versionedTools {
+		if versions := toolVersions[tool]; len(versions) > 0 {
+			pass(fmt.Sprintf("%d %s version(s) installed", len(versions), tool))
 		}
-		pass(fmt.Sprintf("%d %s version(s) installed", len(versions), tool))
 	}
 	return 0
 }
 
-func checkNeedsNode() int {
-	nodeVersions, err := platform.ListToolVersions("node")
-	if err != nil || len(nodeVersions) > 0 {
-		return 0 // node is available
+func checkNeedsNode(toolVersions map[string][]string) int {
+	if len(toolVersions["node"]) > 0 {
+		return 0
 	}
 
 	issues := 0
 	for _, tool := range []string{"pnpm", "yarn"} {
-		versions, err := platform.ListToolVersions(tool)
-		if err != nil || len(versions) == 0 {
-			continue
+		if len(toolVersions[tool]) > 0 {
+			warn(fmt.Sprintf("%s is installed but no node versions found — %s requires Node.js to run", tool, tool))
+			issues++
 		}
-		warn(fmt.Sprintf("%s is installed but no node versions found — %s requires Node.js to run", tool, tool))
-		issues++
 	}
 	return issues
 }

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -1,0 +1,241 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/DriftrLabs/driftr/internal/config"
+	"github.com/DriftrLabs/driftr/internal/platform"
+)
+
+var shimTools = []string{"node", "npm", "npx", "pnpm", "pnpx", "yarn"}
+
+// conflicting node version managers to detect on PATH.
+var conflictingManagers = []string{"nvm", "fnm", "volta", "n"}
+
+func newDoctorCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "doctor",
+		Short: "Check your driftr installation for problems",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			issues := 0
+			issues += checkPath()
+			issues += checkShims()
+			issues += checkShimBinaryPath()
+			issues += checkGlobalDefault()
+			issues += checkDefaultsInstalled()
+			issues += checkConflictingManagers()
+			issues += checkInstalledVersions()
+			issues += checkNeedsNode()
+
+			fmt.Println()
+			if issues == 0 {
+				fmt.Println("No issues found.")
+			} else {
+				fmt.Printf("Found %d issue(s).\n", issues)
+			}
+			return nil
+		},
+	}
+}
+
+func pass(msg string) {
+	fmt.Printf("  ok  %s\n", msg)
+}
+
+func warn(msg string) {
+	fmt.Printf("  !!  %s\n", msg)
+}
+
+func checkPath() int {
+	binDir, err := platform.BinDir()
+	if err != nil {
+		warn("Cannot determine bin directory")
+		return 1
+	}
+
+	pathDirs := filepath.SplitList(os.Getenv("PATH"))
+	for _, dir := range pathDirs {
+		if dir == binDir {
+			pass(binDir + " is on PATH")
+			return 0
+		}
+	}
+
+	warn(binDir + " is not on PATH — shims won't be found")
+	return 1
+}
+
+func checkShims() int {
+	binDir, err := platform.BinDir()
+	if err != nil {
+		warn("Cannot determine bin directory")
+		return 1
+	}
+
+	missing := 0
+	for _, tool := range shimTools {
+		shimPath := filepath.Join(binDir, tool)
+		info, err := os.Stat(shimPath)
+		if err != nil {
+			warn(fmt.Sprintf("Shim missing: %s — run `driftr setup`", tool))
+			missing++
+			continue
+		}
+		if info.Mode()&0o111 == 0 {
+			warn(fmt.Sprintf("Shim not executable: %s — run `driftr setup`", tool))
+			missing++
+		}
+	}
+
+	if missing == 0 {
+		pass(fmt.Sprintf("All %d shims installed", len(shimTools)))
+	}
+	return missing
+}
+
+func checkShimBinaryPath() int {
+	binDir, err := platform.BinDir()
+	if err != nil {
+		return 0
+	}
+
+	currentBin, err := os.Executable()
+	if err != nil {
+		return 0
+	}
+	currentBin, _ = filepath.EvalSymlinks(currentBin)
+
+	// Check the first shim to see where it points.
+	shimPath := filepath.Join(binDir, "node")
+	data, err := os.ReadFile(shimPath)
+	if err != nil {
+		return 0 // already covered by checkShims
+	}
+
+	content := string(data)
+	// Extract the binary path from: exec "/path/to/driftr" shim node "$@"
+	if idx := strings.Index(content, "exec \""); idx >= 0 {
+		rest := content[idx+6:]
+		if end := strings.Index(rest, "\""); end >= 0 {
+			shimBin := rest[:end]
+			resolved, _ := filepath.EvalSymlinks(shimBin)
+			if resolved == "" {
+				resolved = shimBin
+			}
+			if resolved != currentBin {
+				warn(fmt.Sprintf("Shims point to %s but driftr is at %s — run `driftr setup`", shimBin, currentBin))
+				return 1
+			}
+			pass("Shims point to current driftr binary")
+			return 0
+		}
+	}
+
+	return 0
+}
+
+func checkGlobalDefault() int {
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		warn(fmt.Sprintf("Cannot read global config: %s", err))
+		return 1
+	}
+
+	if cfg.Default.GetTool("node") == "" {
+		warn("No global default node version — run `driftr default node@<version>`")
+		return 1
+	}
+
+	pass(fmt.Sprintf("Global default: node %s", cfg.Default.GetTool("node")))
+	return 0
+}
+
+func checkDefaultsInstalled() int {
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		return 0 // already reported by checkGlobalDefault
+	}
+
+	issues := 0
+	for _, tool := range []string{"node", "pnpm", "yarn"} {
+		ver := cfg.Default.GetTool(tool)
+		if ver == "" {
+			continue
+		}
+		binPath, err := platform.ToolBinary(tool, ver)
+		if err != nil {
+			continue
+		}
+		if _, err := os.Stat(binPath); err != nil {
+			warn(fmt.Sprintf("Default %s %s is not installed — run `driftr install %s@%s`", tool, ver, tool, ver))
+			issues++
+		}
+	}
+
+	if issues == 0 {
+		pass("All default versions are installed")
+	}
+	return issues
+}
+
+func checkConflictingManagers() int {
+	binDir, err := platform.BinDir()
+	if err != nil {
+		return 0
+	}
+
+	issues := 0
+	for _, manager := range conflictingManagers {
+		path, err := exec.LookPath(manager)
+		if err != nil {
+			continue
+		}
+		// Ignore if it's our own shim directory.
+		if filepath.Dir(path) == binDir {
+			continue
+		}
+		warn(fmt.Sprintf("%s detected at %s — may conflict with driftr shims", manager, path))
+		issues++
+	}
+
+	if issues == 0 {
+		pass("No conflicting version managers found")
+	}
+	return issues
+}
+
+func checkInstalledVersions() int {
+	for _, tool := range []string{"node", "pnpm", "yarn"} {
+		versions, err := platform.ListToolVersions(tool)
+		if err != nil || len(versions) == 0 {
+			continue
+		}
+		pass(fmt.Sprintf("%d %s version(s) installed", len(versions), tool))
+	}
+	return 0
+}
+
+func checkNeedsNode() int {
+	nodeVersions, err := platform.ListToolVersions("node")
+	if err != nil || len(nodeVersions) > 0 {
+		return 0 // node is available
+	}
+
+	issues := 0
+	for _, tool := range []string{"pnpm", "yarn"} {
+		versions, err := platform.ListToolVersions(tool)
+		if err != nil || len(versions) == 0 {
+			continue
+		}
+		warn(fmt.Sprintf("%s is installed but no node versions found — %s requires Node.js to run", tool, tool))
+		issues++
+	}
+	return issues
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -50,6 +50,7 @@ func NewRootCmd() *cobra.Command {
 		newShimCmd(),
 		newSetupCmd(),
 		newCacheCmd(),
+		newDoctorCmd(),
 		newUpdateCmd(),
 	)
 

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -8,8 +8,13 @@ import (
 	"github.com/DriftrLabs/driftr/internal/platform"
 )
 
-// ShimTools lists the tools for which shims are created.
-var ShimTools = []string{"node", "npm", "npx", "pnpm", "pnpx", "yarn"}
+// shimTools lists the tools for which shims are created.
+var shimTools = []string{"node", "npm", "npx", "pnpm", "pnpx", "yarn"}
+
+// ShimTools returns the list of tools that have shims.
+func ShimTools() []string {
+	return append([]string(nil), shimTools...)
+}
 
 // GenerateShims creates shim shell scripts in ~/.driftr/bin/.
 // Each shim invokes `driftr shim <tool>` to resolve and exec the real binary.
@@ -33,7 +38,7 @@ func GenerateShims() error {
 		return fmt.Errorf("cannot resolve driftr executable path: %w", err)
 	}
 
-	for _, tool := range ShimTools {
+	for _, tool := range shimTools {
 		if err := writeShim(binDir, tool, driftrBin); err != nil {
 			return fmt.Errorf("failed to create shim for %s: %w", tool, err)
 		}

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -8,8 +8,8 @@ import (
 	"github.com/DriftrLabs/driftr/internal/platform"
 )
 
-// shimTools lists the tools for which shims are created in MVP.
-var shimTools = []string{"node", "npm", "npx", "pnpm", "pnpx", "yarn"}
+// ShimTools lists the tools for which shims are created.
+var ShimTools = []string{"node", "npm", "npx", "pnpm", "pnpx", "yarn"}
 
 // GenerateShims creates shim shell scripts in ~/.driftr/bin/.
 // Each shim invokes `driftr shim <tool>` to resolve and exec the real binary.
@@ -33,7 +33,7 @@ func GenerateShims() error {
 		return fmt.Errorf("cannot resolve driftr executable path: %w", err)
 	}
 
-	for _, tool := range shimTools {
+	for _, tool := range ShimTools {
 		if err := writeShim(binDir, tool, driftrBin); err != nil {
 			return fmt.Errorf("failed to create shim for %s: %w", tool, err)
 		}

--- a/internal/shim/shim_test.go
+++ b/internal/shim/shim_test.go
@@ -49,7 +49,7 @@ func TestWriteShim_Executable(t *testing.T) {
 func TestWriteShim_AllTools(t *testing.T) {
 	dir := t.TempDir()
 
-	for _, tool := range shimTools {
+	for _, tool := range ShimTools {
 		if err := writeShim(dir, tool, "/bin/driftr"); err != nil {
 			t.Fatalf("writeShim(%q) error: %v", tool, err)
 		}
@@ -58,18 +58,18 @@ func TestWriteShim_AllTools(t *testing.T) {
 		}
 	}
 
-	// Verify all expected tools are in shimTools.
+	// Verify all expected tools are in ShimTools.
 	expected := map[string]bool{
 		"node": true, "npm": true, "npx": true,
 		"pnpm": true, "pnpx": true, "yarn": true,
 	}
-	for _, tool := range shimTools {
+	for _, tool := range ShimTools {
 		if !expected[tool] {
-			t.Errorf("unexpected tool in shimTools: %q", tool)
+			t.Errorf("unexpected tool in ShimTools: %q", tool)
 		}
 		delete(expected, tool)
 	}
 	for tool := range expected {
-		t.Errorf("missing tool in shimTools: %q", tool)
+		t.Errorf("missing tool in ShimTools: %q", tool)
 	}
 }

--- a/internal/shim/shim_test.go
+++ b/internal/shim/shim_test.go
@@ -49,7 +49,7 @@ func TestWriteShim_Executable(t *testing.T) {
 func TestWriteShim_AllTools(t *testing.T) {
 	dir := t.TempDir()
 
-	for _, tool := range ShimTools {
+	for _, tool := range ShimTools() {
 		if err := writeShim(dir, tool, "/bin/driftr"); err != nil {
 			t.Fatalf("writeShim(%q) error: %v", tool, err)
 		}
@@ -58,18 +58,18 @@ func TestWriteShim_AllTools(t *testing.T) {
 		}
 	}
 
-	// Verify all expected tools are in ShimTools.
+	// Verify all expected tools are in ShimTools().
 	expected := map[string]bool{
 		"node": true, "npm": true, "npx": true,
 		"pnpm": true, "pnpx": true, "yarn": true,
 	}
-	for _, tool := range ShimTools {
+	for _, tool := range ShimTools() {
 		if !expected[tool] {
-			t.Errorf("unexpected tool in ShimTools: %q", tool)
+			t.Errorf("unexpected tool in ShimTools(): %q", tool)
 		}
 		delete(expected, tool)
 	}
 	for tool := range expected {
-		t.Errorf("missing tool in ShimTools: %q", tool)
+		t.Errorf("missing tool in ShimTools(): %q", tool)
 	}
 }


### PR DESCRIPTION
## Summary
Add `driftr doctor` for environment diagnostics with 8 checks:

- **PATH**: verifies `~/.driftr/bin` is on PATH
- **Shims**: all 6 shim scripts exist and are executable
- **Shim binary path**: shims point to the current driftr binary (detects stale paths after upgrades)
- **Global default**: a default node version is configured
- **Defaults installed**: all configured default versions have binaries on disk
- **Conflicting managers**: detects nvm (`$NVM_DIR`), fnm, volta, n on PATH
- **Installed versions**: summary of installed tool counts
- **NeedsNode**: warns if pnpm/yarn installed without any node versions

Also exports `shim.ShimTools` as the single source of truth for the tool list.

Closes #43

## Test plan
- [x] `go build` compiles
- [x] `go vet` passes
- [x] `go test ./...` passes
- [ ] CI passes
- [ ] Manual: `driftr doctor` with correct setup shows all green
- [ ] Manual: `driftr doctor` with missing shim/PATH/default reports issues