### PR TITLE
feat: configure PATH in .zshenv, migrate legacy installs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -164,37 +164,87 @@ main() {
     log ""
     log "driftr v${version} installed successfully!"
     log ""
-    log "Restart your shell or run:"
-    log "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+    case ":${PATH:-}:" in
+        *":${INSTALL_DIR}:"*)
+            log "Run 'driftr --version' to verify."
+            ;;
+        *)
+            log "Open a new shell, or run this in the current shell:"
+            log "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+            ;;
+    esac
     log ""
     log "To enable shell completions:"
     log "  # zsh"
     log "  echo 'eval \"\$(driftr completion zsh)\"' >> ~/.zshrc"
     log "  # bash"
     log "  echo 'eval \"\$(driftr completion bash)\"' >> ~/.bashrc"
+    log "  # fish"
+    log "  driftr completion fish > ~/.config/fish/completions/driftr.fish"
 }
 
 configure_path() {
-    path_line="export PATH=\"${INSTALL_DIR}:\$PATH\""
-
-    # Detect the user's shell profile.
-    shell_name="$(basename "${SHELL:-/bin/sh}")"
-    case "$shell_name" in
-        zsh)  profile="$HOME/.zshrc" ;;
-        bash)
-            if [ -f "$HOME/.bashrc" ]; then
-                profile="$HOME/.bashrc"
-            else
-                profile="$HOME/.bash_profile"
-            fi
+    # Skip if the install dir is already on PATH in the current environment.
+    case ":${PATH:-}:" in
+        *":${INSTALL_DIR}:"*)
+            log "${INSTALL_DIR} already on PATH"
+            return
             ;;
-        *)    profile="$HOME/.profile" ;;
     esac
 
-    # Don't duplicate the entry.
-    if [ -f "$profile" ] && grep -qF "$INSTALL_DIR" "$profile"; then
+    shell_name="$(basename "${SHELL:-/bin/sh}")"
+
+    # Fish uses different syntax and a different config location.
+    if [ "$shell_name" = "fish" ]; then
+        fish_conf_dir="${XDG_CONFIG_HOME:-$HOME/.config}/fish/conf.d"
+        fish_profile="${fish_conf_dir}/driftr.fish"
+        if [ -f "$fish_profile" ] && grep -qF "$INSTALL_DIR" "$fish_profile"; then
+            return
+        fi
+        mkdir -p "$fish_conf_dir"
+        printf '# Driftr\nset -gx PATH %s $PATH\n' "$INSTALL_DIR" >> "$fish_profile"
+        log "Added ${INSTALL_DIR} to PATH in ${fish_profile}"
         return
     fi
+
+    path_line="export PATH=\"${INSTALL_DIR}:\$PATH\""
+
+    # Pick the profile that is read by ALL invocations of the shell (not just
+    # interactive ones) so driftr works in scripts, IDE terminals, and cron.
+    #   - zsh:  .zshenv is sourced on every invocation
+    #   - bash: .bash_profile for login shells, .bashrc for interactive;
+    #           also write to .profile as a POSIX fallback for non-login
+    #           non-interactive shells that source it
+    case "$shell_name" in
+        zsh)
+            profile="${ZDOTDIR:-$HOME}/.zshenv"
+            ;;
+        bash)
+            if [ -f "$HOME/.bash_profile" ] || [ ! -f "$HOME/.bashrc" ]; then
+                profile="$HOME/.bash_profile"
+            else
+                profile="$HOME/.bashrc"
+            fi
+            ;;
+        *)
+            profile="$HOME/.profile"
+            ;;
+    esac
+
+    # Dedup: only check the target file. If the user has the line in another
+    # rc file from a prior install, warn but still write to the new target so
+    # non-interactive shells pick it up.
+    if [ -f "$profile" ] && grep -qF "$INSTALL_DIR" "$profile"; then
+        log "${INSTALL_DIR} already configured in ${profile}"
+        return
+    fi
+
+    for stale in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.profile" "$HOME/.bash_profile"; do
+        [ "$stale" = "$profile" ] && continue
+        if [ -f "$stale" ] && grep -qF "$INSTALL_DIR" "$stale"; then
+            log "note: ${INSTALL_DIR} is also in ${stale} — consider removing that entry to avoid duplicate PATH"
+        fi
+    done
 
     printf '\n# Driftr\n%s\n' "$path_line" >> "$profile"
     log "Added ${INSTALL_DIR} to PATH in ${profile}"

--- a/install.sh
+++ b/install.sh
@@ -184,14 +184,6 @@ main() {
 }
 
 configure_path() {
-    # Skip if the install dir is already on PATH in the current environment.
-    case ":${PATH:-}:" in
-        *":${INSTALL_DIR}:"*)
-            log "${INSTALL_DIR} already on PATH"
-            return
-            ;;
-    esac
-
     shell_name="$(basename "${SHELL:-/bin/sh}")"
 
     # Fish uses different syntax and a different config location.
@@ -212,19 +204,14 @@ configure_path() {
     # Pick the profile that is read by ALL invocations of the shell (not just
     # interactive ones) so driftr works in scripts, IDE terminals, and cron.
     #   - zsh:  .zshenv is sourced on every invocation
-    #   - bash: .bash_profile for login shells, .bashrc for interactive;
-    #           also write to .profile as a POSIX fallback for non-login
-    #           non-interactive shells that source it
+    #   - bash: .bash_profile is read by login shells; non-interactive children
+    #           inherit PATH from the login shell environment
     case "$shell_name" in
         zsh)
             profile="${ZDOTDIR:-$HOME}/.zshenv"
             ;;
         bash)
-            if [ -f "$HOME/.bash_profile" ] || [ ! -f "$HOME/.bashrc" ]; then
-                profile="$HOME/.bash_profile"
-            else
-                profile="$HOME/.bashrc"
-            fi
+            profile="$HOME/.bash_profile"
             ;;
         *)
             profile="$HOME/.profile"

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/DriftrLabs/driftr/internal/config"
+	"github.com/DriftrLabs/driftr/internal/pathsetup"
 	"github.com/DriftrLabs/driftr/internal/platform"
 	"github.com/DriftrLabs/driftr/internal/shim"
 )
@@ -23,7 +24,8 @@ var conflictingBinaries = []string{"fnm", "volta", "n"}
 const shimExecPrefix = `exec "`
 
 func newDoctorCmd() *cobra.Command {
-	return &cobra.Command{
+	var fix bool
+	cmd := &cobra.Command{
 		Use:   "doctor",
 		Short: "Check your driftr installation for problems",
 		Args:  cobra.NoArgs,
@@ -47,6 +49,7 @@ func newDoctorCmd() *cobra.Command {
 			}
 
 			issues += checkPath(binDir)
+			issues += checkShellRCPlacement(binDir, fix)
 			issues += checkShims(binDir)
 			issues += checkShimBinaryPath(binDir)
 			issues += checkGlobalDefault(cfg, cfgErr)
@@ -64,6 +67,8 @@ func newDoctorCmd() *cobra.Command {
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&fix, "fix", false, "automatically fix detected PATH configuration issues")
+	return cmd
 }
 
 func pass(msg string) {
@@ -84,6 +89,49 @@ func checkPath(binDir string) int {
 	}
 
 	warn(binDir + " is not on PATH — shims won't be found")
+	return 1
+}
+
+// checkShellRCPlacement verifies that binDir is exported from a shell rc file
+// that every invocation of the shell sources (e.g. .zshenv for zsh). Entries
+// in interactive-only files (.zshrc, .bashrc) are flagged as stale because
+// non-interactive shells, scripts, cron, and IDE subprocesses won't see them.
+func checkShellRCPlacement(binDir string, fix bool) int {
+	r, err := pathsetup.Detect(binDir)
+	if err != nil {
+		warn(fmt.Sprintf("Cannot inspect shell rc files: %s", err))
+		return 1
+	}
+
+	if !r.NeedsFix() {
+		pass(fmt.Sprintf("PATH configured in %s (universal shell coverage)", r.Target))
+		return 0
+	}
+
+	switch {
+	case len(r.StaleFiles) > 0:
+		warn(fmt.Sprintf("PATH is only in interactive rc file(s): %s",
+			strings.Join(r.StaleFiles, ", ")))
+		warn(fmt.Sprintf("  scripts, cron, and non-interactive shells won't find driftr — target %s", r.Target))
+	default:
+		warn(fmt.Sprintf("PATH is not configured in any shell rc file — target %s", r.Target))
+	}
+
+	if !fix {
+		warn("  run `driftr doctor --fix` to repair")
+		return 1
+	}
+
+	wrote, file, applyErr := pathsetup.Apply(r)
+	if applyErr != nil {
+		warn(fmt.Sprintf("  fix failed: %s", applyErr))
+		return 1
+	}
+	if wrote {
+		pass(fmt.Sprintf("  fixed: added PATH export to %s (open a new shell to use it)", file))
+		return 0
+	}
+	warn("  nothing to fix")
 	return 1
 }
 

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -55,6 +56,6 @@ func migratePathConfig() {
 	}
 	fmt.Printf("Migrated PATH config to %s for universal shell coverage.\n", file)
 	if len(r.StaleFiles) > 0 {
-		fmt.Printf("  Note: legacy entries remain in %s — safe to remove.\n", r.StaleFiles[0])
+		fmt.Printf("  Note: legacy entries remain in %s — safe to remove.\n", strings.Join(r.StaleFiles, ", "))
 	}
 }

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/DriftrLabs/driftr/internal/pathsetup"
+	"github.com/DriftrLabs/driftr/internal/platform"
 	"github.com/DriftrLabs/driftr/internal/updater"
 )
 
@@ -24,8 +26,35 @@ func newUpdateCmd() *cobra.Command {
 				fmt.Printf("driftr v%s is already the latest version.\n", Version)
 			} else {
 				fmt.Printf("Updated successfully to driftr v%s!\n", newVersion)
+				migratePathConfig()
 			}
 			return nil
 		},
+	}
+}
+
+// migratePathConfig is a best-effort repair of legacy PATH placement after
+// a successful self-update. Older installers wrote the PATH export to .zshrc
+// (interactive only); this moves the configuration to a file that every shell
+// invocation sources, so driftr works in scripts and non-interactive shells.
+//
+// Silent on any failure — self-update's primary job (binary swap) already
+// succeeded and we don't want to mask that with rc-file errors.
+func migratePathConfig() {
+	binDir, err := platform.BinDir()
+	if err != nil {
+		return
+	}
+	r, err := pathsetup.Detect(binDir)
+	if err != nil || !r.NeedsFix() {
+		return
+	}
+	wrote, file, err := pathsetup.Apply(r)
+	if err != nil || !wrote {
+		return
+	}
+	fmt.Printf("Migrated PATH config to %s for universal shell coverage.\n", file)
+	if len(r.StaleFiles) > 0 {
+		fmt.Printf("  Note: legacy entries remain in %s — safe to remove.\n", r.StaleFiles[0])
 	}
 }

--- a/internal/pathsetup/pathsetup.go
+++ b/internal/pathsetup/pathsetup.go
@@ -94,21 +94,27 @@ func binDirNeedles(binDir string) []string {
 // Apply writes the PATH export to the recommended target file if missing.
 // Returns (true, target) when it wrote, (false, "") when no change was needed.
 // Never removes entries from stale files — that's left to the user.
-func Apply(r Result) (bool, string, error) {
+func Apply(r Result) (wrote bool, target string, err error) {
 	if !r.NeedsFix() {
 		return false, "", nil
 	}
 
-	if err := os.MkdirAll(filepath.Dir(r.Target), 0o755); err != nil {
+	if err = os.MkdirAll(filepath.Dir(r.Target), 0o755); err != nil {
 		return false, "", fmt.Errorf("create profile dir: %w", err)
 	}
 
 	line := exportLine(r.Shell, r.BinDir)
-	f, err := os.OpenFile(r.Target, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
-	if err != nil {
-		return false, "", fmt.Errorf("open %s: %w", r.Target, err)
+	f, ferr := os.OpenFile(r.Target, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if ferr != nil {
+		return false, "", fmt.Errorf("open %s: %w", r.Target, ferr)
 	}
-	defer f.Close()
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("close %s: %w", r.Target, cerr)
+			wrote = false
+			target = ""
+		}
+	}()
 
 	// Leading newline when file has content to avoid gluing to prior line.
 	info, _ := f.Stat()
@@ -116,8 +122,8 @@ func Apply(r Result) (bool, string, error) {
 	if info != nil && info.Size() == 0 {
 		prefix = ""
 	}
-	if _, err := fmt.Fprintf(f, "%s# Driftr\n%s\n", prefix, line); err != nil {
-		return false, "", fmt.Errorf("write %s: %w", r.Target, err)
+	if _, werr := fmt.Fprintf(f, "%s# Driftr\n%s\n", prefix, line); werr != nil {
+		return false, "", fmt.Errorf("write %s: %w", r.Target, werr)
 	}
 
 	return true, r.Target, nil
@@ -144,8 +150,12 @@ func DetectShell() Shell {
 	}
 }
 
-// TargetProfile returns the recommended rc file to export PATH from so that
-// every shell invocation (interactive and non-interactive) picks it up.
+// TargetProfile returns the recommended rc file to export PATH from for the
+// widest shell coverage. For zsh this is .zshenv (every invocation). For fish
+// this is conf.d (every invocation). For bash this is .bash_profile (login
+// shells); non-interactive children inherit PATH from the login shell env, so
+// coverage is not truly universal — it depends on the terminal launching a
+// login shell, which most macOS and Linux terminal emulators do.
 func TargetProfile(shell Shell) (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/internal/pathsetup/pathsetup.go
+++ b/internal/pathsetup/pathsetup.go
@@ -1,0 +1,274 @@
+// Package pathsetup detects and repairs shell PATH configuration for driftr.
+//
+// The goal is "work everywhere": driftr must be on PATH in interactive shells,
+// non-interactive shells, scripts, cron, and IDE subprocesses. That requires
+// PATH to be exported from a file that every invocation of the shell sources
+// (e.g. .zshenv for zsh), not only interactive rc files (.zshrc, .bashrc).
+package pathsetup
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// Shell is the detected user shell.
+type Shell string
+
+const (
+	ShellZsh     Shell = "zsh"
+	ShellBash    Shell = "bash"
+	ShellFish    Shell = "fish"
+	ShellUnknown Shell = "unknown"
+)
+
+// Result describes the current PATH configuration state for the given binDir.
+type Result struct {
+	Shell         Shell
+	BinDir        string
+	Target        string   // recommended rc file for universal coverage
+	InTarget      bool     // target file already configures binDir
+	StaleFiles    []string // other rc files that configure binDir
+	InProcessPATH bool     // current process's PATH includes binDir
+}
+
+// NeedsFix returns true when binDir is not configured in the recommended
+// target file. Stale entries in other rc files still count as "needs fix"
+// because they won't cover non-interactive shells.
+func (r Result) NeedsFix() bool {
+	return !r.InTarget
+}
+
+// Detect inspects the user's shell configuration and reports the state.
+func Detect(binDir string) (Result, error) {
+	shell := DetectShell()
+	target, err := TargetProfile(shell)
+	if err != nil {
+		return Result{}, err
+	}
+
+	needles := binDirNeedles(binDir)
+
+	inTarget, err := fileMentionsAny(target, needles)
+	if err != nil {
+		return Result{}, err
+	}
+
+	stale, err := scanStale(shell, target, needles)
+	if err != nil {
+		return Result{}, err
+	}
+
+	return Result{
+		Shell:         shell,
+		BinDir:        binDir,
+		Target:        target,
+		InTarget:      inTarget,
+		StaleFiles:    stale,
+		InProcessPATH: pathContains(os.Getenv("PATH"), binDir),
+	}, nil
+}
+
+// binDirNeedles returns the substrings that may represent binDir in an rc
+// file. Users (and the installer) often write the path home-relative using
+// $HOME or ~, so we look for all three forms.
+func binDirNeedles(binDir string) []string {
+	needles := []string{binDir}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return needles
+	}
+	cleanHome := filepath.Clean(home)
+	cleanBin := filepath.Clean(binDir)
+	if strings.HasPrefix(cleanBin, cleanHome+string(filepath.Separator)) {
+		rel := strings.TrimPrefix(cleanBin, cleanHome)
+		needles = append(needles, "$HOME"+rel, "~"+rel, "${HOME}"+rel)
+	}
+	return needles
+}
+
+// Apply writes the PATH export to the recommended target file if missing.
+// Returns (true, target) when it wrote, (false, "") when no change was needed.
+// Never removes entries from stale files — that's left to the user.
+func Apply(r Result) (bool, string, error) {
+	if !r.NeedsFix() {
+		return false, "", nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(r.Target), 0o755); err != nil {
+		return false, "", fmt.Errorf("create profile dir: %w", err)
+	}
+
+	line := exportLine(r.Shell, r.BinDir)
+	f, err := os.OpenFile(r.Target, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return false, "", fmt.Errorf("open %s: %w", r.Target, err)
+	}
+	defer f.Close()
+
+	// Leading newline when file has content to avoid gluing to prior line.
+	info, _ := f.Stat()
+	prefix := "\n"
+	if info != nil && info.Size() == 0 {
+		prefix = ""
+	}
+	if _, err := fmt.Fprintf(f, "%s# Driftr\n%s\n", prefix, line); err != nil {
+		return false, "", fmt.Errorf("write %s: %w", r.Target, err)
+	}
+
+	return true, r.Target, nil
+}
+
+// DetectShell returns the user's shell based on $SHELL, defaulting to unknown.
+func DetectShell() Shell {
+	sh := os.Getenv("SHELL")
+	if sh == "" {
+		if runtime.GOOS == "windows" {
+			return ShellUnknown
+		}
+		return ShellUnknown
+	}
+	switch filepath.Base(sh) {
+	case "zsh":
+		return ShellZsh
+	case "bash":
+		return ShellBash
+	case "fish":
+		return ShellFish
+	default:
+		return ShellUnknown
+	}
+}
+
+// TargetProfile returns the recommended rc file to export PATH from so that
+// every shell invocation (interactive and non-interactive) picks it up.
+func TargetProfile(shell Shell) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("home dir: %w", err)
+	}
+
+	switch shell {
+	case ShellZsh:
+		if zdotdir := os.Getenv("ZDOTDIR"); zdotdir != "" {
+			return filepath.Join(zdotdir, ".zshenv"), nil
+		}
+		return filepath.Join(home, ".zshenv"), nil
+	case ShellBash:
+		// .bash_profile is read by login shells, which most macOS/Linux
+		// terminal sessions are. Non-interactive children inherit PATH
+		// from the login shell env.
+		return filepath.Join(home, ".bash_profile"), nil
+	case ShellFish:
+		base := os.Getenv("XDG_CONFIG_HOME")
+		if base == "" {
+			base = filepath.Join(home, ".config")
+		}
+		return filepath.Join(base, "fish", "conf.d", "driftr.fish"), nil
+	default:
+		return filepath.Join(home, ".profile"), nil
+	}
+}
+
+// StaleCandidates returns rc files that may contain legacy PATH entries.
+func StaleCandidates(shell Shell) ([]string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+
+	switch shell {
+	case ShellZsh:
+		zdotdir := os.Getenv("ZDOTDIR")
+		if zdotdir == "" {
+			zdotdir = home
+		}
+		return []string{
+			filepath.Join(zdotdir, ".zshrc"),
+			filepath.Join(zdotdir, ".zprofile"),
+			filepath.Join(home, ".profile"),
+		}, nil
+	case ShellBash:
+		return []string{
+			filepath.Join(home, ".bashrc"),
+			filepath.Join(home, ".profile"),
+		}, nil
+	case ShellFish:
+		base := os.Getenv("XDG_CONFIG_HOME")
+		if base == "" {
+			base = filepath.Join(home, ".config")
+		}
+		return []string{filepath.Join(base, "fish", "config.fish")}, nil
+	default:
+		return nil, nil
+	}
+}
+
+func scanStale(shell Shell, target string, needles []string) ([]string, error) {
+	candidates, err := StaleCandidates(shell)
+	if err != nil {
+		return nil, err
+	}
+	var stale []string
+	for _, c := range candidates {
+		if c == target {
+			continue
+		}
+		ok, err := fileMentionsAny(c, needles)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			stale = append(stale, c)
+		}
+	}
+	return stale, nil
+}
+
+func fileMentionsAny(path string, needles []string) (bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	defer f.Close()
+
+	reader := bufio.NewReader(f)
+	for {
+		line, err := reader.ReadString('\n')
+		for _, n := range needles {
+			if strings.Contains(line, n) {
+				return true, nil
+			}
+		}
+		if err != nil {
+			if err == io.EOF {
+				return false, nil
+			}
+			return false, err
+		}
+	}
+}
+
+func exportLine(shell Shell, binDir string) string {
+	if shell == ShellFish {
+		return fmt.Sprintf("set -gx PATH %s $PATH", binDir)
+	}
+	return fmt.Sprintf(`export PATH="%s:$PATH"`, binDir)
+}
+
+func pathContains(pathEnv, binDir string) bool {
+	clean := filepath.Clean(binDir)
+	for _, dir := range filepath.SplitList(pathEnv) {
+		if filepath.Clean(dir) == clean {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/pathsetup/pathsetup_test.go
+++ b/internal/pathsetup/pathsetup_test.go
@@ -1,0 +1,337 @@
+package pathsetup
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// setHome creates a temp dir, sets HOME to it, and returns the path.
+func setHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("ZDOTDIR", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	return dir
+}
+
+func TestDetectShell(t *testing.T) {
+	tests := []struct {
+		sh   string
+		want Shell
+	}{
+		{"/bin/zsh", ShellZsh},
+		{"/usr/bin/bash", ShellBash},
+		{"/opt/homebrew/bin/fish", ShellFish},
+		{"/bin/dash", ShellUnknown},
+		{"", ShellUnknown},
+	}
+	for _, tc := range tests {
+		t.Run(tc.sh, func(t *testing.T) {
+			t.Setenv("SHELL", tc.sh)
+			if got := DetectShell(); got != tc.want {
+				t.Errorf("DetectShell(%q) = %v, want %v", tc.sh, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTargetProfile_Zsh(t *testing.T) {
+	home := setHome(t)
+	got, err := TargetProfile(ShellZsh)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(home, ".zshenv")
+	if got != want {
+		t.Errorf("target = %q, want %q", got, want)
+	}
+}
+
+func TestTargetProfile_ZshHonorsZDOTDIR(t *testing.T) {
+	setHome(t)
+	custom := t.TempDir()
+	t.Setenv("ZDOTDIR", custom)
+	got, err := TargetProfile(ShellZsh)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(custom, ".zshenv")
+	if got != want {
+		t.Errorf("target = %q, want %q", got, want)
+	}
+}
+
+func TestTargetProfile_Bash(t *testing.T) {
+	home := setHome(t)
+	got, err := TargetProfile(ShellBash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(home, ".bash_profile")
+	if got != want {
+		t.Errorf("target = %q, want %q", got, want)
+	}
+}
+
+func TestTargetProfile_Fish(t *testing.T) {
+	home := setHome(t)
+	got, err := TargetProfile(ShellFish)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(home, ".config", "fish", "conf.d", "driftr.fish")
+	if got != want {
+		t.Errorf("target = %q, want %q", got, want)
+	}
+}
+
+func TestTargetProfile_FishHonorsXDG(t *testing.T) {
+	setHome(t)
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	got, err := TargetProfile(ShellFish)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(xdg, "fish", "conf.d", "driftr.fish")
+	if got != want {
+		t.Errorf("target = %q, want %q", got, want)
+	}
+}
+
+func TestDetect_EmptyEnv(t *testing.T) {
+	home := setHome(t)
+	t.Setenv("SHELL", "/bin/zsh")
+	t.Setenv("PATH", "/usr/bin:/bin")
+
+	binDir := filepath.Join(home, ".driftr", "bin")
+	r, err := Detect(binDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Shell != ShellZsh {
+		t.Errorf("shell = %v, want zsh", r.Shell)
+	}
+	if r.InTarget {
+		t.Errorf("InTarget = true, want false (.zshenv does not exist)")
+	}
+	if len(r.StaleFiles) != 0 {
+		t.Errorf("StaleFiles = %v, want empty", r.StaleFiles)
+	}
+	if r.InProcessPATH {
+		t.Errorf("InProcessPATH = true, want false")
+	}
+	if !r.NeedsFix() {
+		t.Errorf("NeedsFix = false, want true")
+	}
+}
+
+func TestDetect_StaleInZshrc(t *testing.T) {
+	home := setHome(t)
+	t.Setenv("SHELL", "/bin/zsh")
+
+	binDir := filepath.Join(home, ".driftr", "bin")
+	zshrc := filepath.Join(home, ".zshrc")
+	writeFile(t, zshrc, "# legacy\nexport PATH=\""+binDir+":$PATH\"\n")
+
+	r, err := Detect(binDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.InTarget {
+		t.Errorf("InTarget = true, want false")
+	}
+	if len(r.StaleFiles) != 1 || r.StaleFiles[0] != zshrc {
+		t.Errorf("StaleFiles = %v, want [%s]", r.StaleFiles, zshrc)
+	}
+	if !r.NeedsFix() {
+		t.Errorf("NeedsFix = false, want true")
+	}
+}
+
+func TestDetect_AlreadyInTarget(t *testing.T) {
+	home := setHome(t)
+	t.Setenv("SHELL", "/bin/zsh")
+
+	binDir := filepath.Join(home, ".driftr", "bin")
+	zshenv := filepath.Join(home, ".zshenv")
+	writeFile(t, zshenv, "export PATH=\""+binDir+":$PATH\"\n")
+
+	r, err := Detect(binDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !r.InTarget {
+		t.Errorf("InTarget = false, want true")
+	}
+	if r.NeedsFix() {
+		t.Errorf("NeedsFix = true, want false")
+	}
+}
+
+func TestApply_CreatesZshenv(t *testing.T) {
+	home := setHome(t)
+	t.Setenv("SHELL", "/bin/zsh")
+
+	binDir := filepath.Join(home, ".driftr", "bin")
+	r, err := Detect(binDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wrote, file, err := Apply(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !wrote {
+		t.Fatal("Apply did not write")
+	}
+	want := filepath.Join(home, ".zshenv")
+	if file != want {
+		t.Errorf("wrote to %q, want %q", file, want)
+	}
+	content := readFile(t, file)
+	if !strings.Contains(content, "export PATH=\""+binDir+":$PATH\"") {
+		t.Errorf("content missing export line:\n%s", content)
+	}
+	if !strings.Contains(content, "# Driftr") {
+		t.Errorf("content missing # Driftr marker:\n%s", content)
+	}
+}
+
+func TestApply_NoOpWhenInTarget(t *testing.T) {
+	home := setHome(t)
+	t.Setenv("SHELL", "/bin/zsh")
+
+	binDir := filepath.Join(home, ".driftr", "bin")
+	zshenv := filepath.Join(home, ".zshenv")
+	original := "export PATH=\"" + binDir + ":$PATH\"\n"
+	writeFile(t, zshenv, original)
+
+	r, err := Detect(binDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrote, file, err := Apply(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wrote {
+		t.Errorf("Apply wrote when target already had entry")
+	}
+	if file != "" {
+		t.Errorf("file = %q, want empty", file)
+	}
+	if got := readFile(t, zshenv); got != original {
+		t.Errorf("file was modified:\n%s", got)
+	}
+}
+
+func TestApply_AppendsWithLeadingNewline(t *testing.T) {
+	home := setHome(t)
+	t.Setenv("SHELL", "/bin/zsh")
+
+	binDir := filepath.Join(home, ".driftr", "bin")
+	zshenv := filepath.Join(home, ".zshenv")
+	writeFile(t, zshenv, "export FOO=bar\n")
+
+	r, err := Detect(binDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := Apply(r); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, zshenv)
+	wantPrefix := "export FOO=bar\n\n# Driftr\n"
+	if !strings.HasPrefix(got, wantPrefix) {
+		t.Errorf("content does not preserve prior line with newline separator:\n%s", got)
+	}
+}
+
+func TestApply_Fish(t *testing.T) {
+	home := setHome(t)
+	t.Setenv("SHELL", "/opt/homebrew/bin/fish")
+
+	binDir := filepath.Join(home, ".driftr", "bin")
+	r, err := Detect(binDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrote, file, err := Apply(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !wrote {
+		t.Fatal("Apply did not write")
+	}
+	want := filepath.Join(home, ".config", "fish", "conf.d", "driftr.fish")
+	if file != want {
+		t.Errorf("wrote to %q, want %q", file, want)
+	}
+	content := readFile(t, file)
+	if !strings.Contains(content, "set -gx PATH "+binDir+" $PATH") {
+		t.Errorf("content missing fish syntax:\n%s", content)
+	}
+}
+
+func TestDetect_HomeRelativeForms(t *testing.T) {
+	home := setHome(t)
+	t.Setenv("SHELL", "/bin/zsh")
+
+	binDir := filepath.Join(home, ".driftr", "bin")
+
+	// Each rc file uses a different form of the home-relative path.
+	writeFile(t, filepath.Join(home, ".zshenv"), "export PATH=\"$HOME/.driftr/bin:$PATH\"\n")
+	writeFile(t, filepath.Join(home, ".zshrc"), "export PATH=\"~/.driftr/bin:$PATH\"\n")
+	writeFile(t, filepath.Join(home, ".zprofile"), "export PATH=\"${HOME}/.driftr/bin:$PATH\"\n")
+
+	r, err := Detect(binDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !r.InTarget {
+		t.Errorf("InTarget = false, want true ($HOME form in .zshenv)")
+	}
+	// Both .zshrc (~) and .zprofile (${HOME}) should register as stale.
+	if len(r.StaleFiles) != 2 {
+		t.Errorf("StaleFiles = %v, want 2 entries (~ and ${HOME} forms)", r.StaleFiles)
+	}
+}
+
+func TestDetect_InProcessPATH(t *testing.T) {
+	home := setHome(t)
+	binDir := filepath.Join(home, ".driftr", "bin")
+	t.Setenv("SHELL", "/bin/zsh")
+	t.Setenv("PATH", binDir+":/usr/bin")
+
+	r, err := Detect(binDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !r.InProcessPATH {
+		t.Errorf("InProcessPATH = false, want true")
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}


### PR DESCRIPTION
## Summary
- install.sh writes PATH export to `.zshenv` (zsh) / `.bash_profile` (bash) / `conf.d/driftr.fish` (fish) so driftr works in non-interactive shells, scripts, and cron
- new `driftr doctor --fix` detects legacy `.zshrc`-only placement and migrates
- `driftr self-update` auto-migrates after successful binary swap
- shared logic in new `internal/pathsetup` package