### PR TITLE
feat(ci): add cross-shell PATH e2e test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,9 @@ jobs:
             -f Dockerfile.path-e2e \
             -t driftr-path-e2e-alpine .
       - name: Run
-        run: docker run --rm driftr-path-e2e-alpine
+        # SKIP_SHIM_TESTS: Node.js official binaries are glibc-only and will
+        # not exec on musl libc. Phase 1 already proves driftr works on musl.
+        run: docker run --rm -e SKIP_SHIM_TESTS=1 driftr-path-e2e-alpine
 
   path-e2e-macos:
     name: PATH e2e (macOS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,65 @@ jobs:
         run: docker build -f Dockerfile.test -t driftr-test .
       - name: Run integration tests
         run: docker run --rm driftr-test
+
+  path-e2e-docker:
+    name: PATH e2e (${{ matrix.shell }})
+    runs-on: ubuntu-latest
+    needs: [test]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shell: zsh
+            shell_pkgs: "zsh"
+          - shell: bash
+            shell_pkgs: "bash"
+          - shell: fish
+            shell_pkgs: "fish"
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build image
+        run: |
+          docker build \
+            --build-arg SHELL_PKGS="${{ matrix.shell_pkgs }}" \
+            --build-arg TEST_SHELL=${{ matrix.shell }} \
+            -f Dockerfile.path-e2e \
+            -t driftr-path-e2e-${{ matrix.shell }} .
+      - name: Run
+        run: docker run --rm driftr-path-e2e-${{ matrix.shell }}
+
+  path-e2e-alpine:
+    name: PATH e2e (alpine/musl)
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build image
+        run: |
+          docker build \
+            --build-arg BASE_IMAGE=alpine:3.21 \
+            --build-arg SHELL_PKGS="bash zsh fish" \
+            --build-arg TEST_SHELL=bash \
+            -f Dockerfile.path-e2e \
+            -t driftr-path-e2e-alpine .
+      - name: Run
+        run: docker run --rm driftr-path-e2e-alpine
+
+  path-e2e-macos:
+    name: PATH e2e (macOS)
+    runs-on: macos-latest
+    needs: [test]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+          cache: true
+      - name: Install fish
+        run: brew install fish
+      - name: Build driftr
+        run: go build -o /tmp/driftr ./cmd/driftr/
+      - name: Run PATH e2e
+        run: |
+          export PATH="/tmp:$PATH"
+          TEST_SHELL=all sh test_path_e2e.sh

--- a/Dockerfile.path-e2e
+++ b/Dockerfile.path-e2e
@@ -1,0 +1,32 @@
+ARG BASE_IMAGE=debian:bookworm-slim
+
+FROM golang:1.26-bookworm AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o /usr/local/bin/driftr ./cmd/driftr/
+
+FROM ${BASE_IMAGE}
+
+ARG SHELL_PKGS="bash"
+ARG TEST_SHELL=bash
+
+COPY scripts/install-deps.sh /install-deps.sh
+RUN sh /install-deps.sh "${SHELL_PKGS}"
+
+COPY --from=builder /usr/local/bin/driftr /usr/local/bin/driftr
+
+# Support both Debian (useradd) and Alpine (adduser -D)
+RUN id driftr 2>/dev/null || \
+    (command -v useradd > /dev/null 2>&1 && useradd -m -s /bin/sh driftr) || \
+    adduser -D -s /bin/sh driftr
+
+USER driftr
+WORKDIR /home/driftr
+ENV TEST_SHELL=${TEST_SHELL}
+
+COPY --chown=driftr:driftr test_path_e2e.sh install.sh ./
+RUN chmod +x test_path_e2e.sh
+
+CMD ["/home/driftr/test_path_e2e.sh"]

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Install shell packages — abstracts apt-get (Debian) and apk (Alpine).
+# Usage: sh install-deps.sh "zsh fish bash"
+set -eu
+pkgs="$1"
+if command -v apt-get > /dev/null 2>&1; then
+    apt-get update && apt-get install -y --no-install-recommends ca-certificates curl $pkgs
+    rm -rf /var/lib/apt/lists/*
+elif command -v apk > /dev/null 2>&1; then
+    apk add --no-cache ca-certificates curl $pkgs
+else
+    echo "error: no supported package manager found" >&2
+    exit 1
+fi

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -4,7 +4,8 @@
 set -eu
 pkgs="$1"
 if command -v apt-get > /dev/null 2>&1; then
-    apt-get update && apt-get install -y --no-install-recommends ca-certificates curl $pkgs
+    # libatomic1: required by Node.js binaries on ARM64 Debian
+    apt-get update && apt-get install -y --no-install-recommends ca-certificates curl libatomic1 $pkgs
     rm -rf /var/lib/apt/lists/*
 elif command -v apk > /dev/null 2>&1; then
     apk add --no-cache ca-certificates curl $pkgs

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -2,6 +2,10 @@
 # Install shell packages — abstracts apt-get (Debian) and apk (Alpine).
 # Usage: sh install-deps.sh "zsh fish bash"
 set -eu
+if [ "$#" -lt 1 ]; then
+    printf 'usage: sh install-deps.sh "<pkg1> [pkg2 ...]"\n' >&2
+    exit 1
+fi
 pkgs="$1"
 if command -v apt-get > /dev/null 2>&1; then
     # libatomic1: required by Node.js binaries on ARM64 Debian
@@ -10,6 +14,6 @@ if command -v apt-get > /dev/null 2>&1; then
 elif command -v apk > /dev/null 2>&1; then
     apk add --no-cache ca-certificates curl $pkgs
 else
-    echo "error: no supported package manager found" >&2
+    printf 'error: no supported package manager found\n' >&2
     exit 1
 fi

--- a/test_path_e2e.sh
+++ b/test_path_e2e.sh
@@ -157,14 +157,15 @@ run_fish_tests() {
         grep -q 'set -gx PATH' "$FISH_CONF"
 
     # fish sources conf.d on every invocation, interactive or not.
-    # TMPDIR is required on macOS: fish uses it for its universal variables
-    # socket (fishd). Linux fish works without it; macOS fish does not.
-    FISH_TMPDIR="${TMPDIR:-/tmp}"
-    assert_cmd "fish: non-interactive invocation resolves driftr" \
-        env -i HOME="$HOME" PATH="$CLEAN_PATH" TMPDIR="$FISH_TMPDIR" \
+    # env -i is too aggressive for fish 4.x (Rust rewrite): it needs HOME,
+    # TMPDIR, USER, and potentially XDG_DATA_DIRS to start cleanly. Instead,
+    # strip only the install dir from PATH — same property, less fragile.
+    PATH_WITHOUT_INSTALL="$(echo "$PATH" | tr ':' '\n' | grep -vF "$INSTALL_DIR" | tr '\n' ':' | sed 's/:$//')"
+    assert_cmd "fish: non-interactive invocation sources conf.d" \
+        env PATH="$PATH_WITHOUT_INSTALL" \
         fish -c "command -v $SENTINEL"
     assert_cmd "fish: type -q succeeds" \
-        env -i HOME="$HOME" PATH="$CLEAN_PATH" TMPDIR="$FISH_TMPDIR" \
+        env PATH="$PATH_WITHOUT_INSTALL" \
         fish -c "type -q $SENTINEL"
 }
 

--- a/test_path_e2e.sh
+++ b/test_path_e2e.sh
@@ -157,11 +157,14 @@ run_fish_tests() {
         grep -q 'set -gx PATH' "$FISH_CONF"
 
     # fish sources conf.d on every invocation, interactive or not.
+    # TMPDIR is required on macOS: fish uses it for its universal variables
+    # socket (fishd). Linux fish works without it; macOS fish does not.
+    FISH_TMPDIR="${TMPDIR:-/tmp}"
     assert_cmd "fish: non-interactive invocation resolves driftr" \
-        env -i HOME="$HOME" PATH="$CLEAN_PATH" \
+        env -i HOME="$HOME" PATH="$CLEAN_PATH" TMPDIR="$FISH_TMPDIR" \
         fish -c "command -v $SENTINEL"
     assert_cmd "fish: type -q succeeds" \
-        env -i HOME="$HOME" PATH="$CLEAN_PATH" \
+        env -i HOME="$HOME" PATH="$CLEAN_PATH" TMPDIR="$FISH_TMPDIR" \
         fish -c "type -q $SENTINEL"
 }
 

--- a/test_path_e2e.sh
+++ b/test_path_e2e.sh
@@ -1,0 +1,190 @@
+#!/bin/sh
+# PATH e2e tests — verify that install.sh configure_path() writes the correct
+# shell rc file and that a fresh shell subprocess with a scrubbed environment
+# finds driftr's bin dir on PATH automatically.
+#
+# Prerequisites:
+#   - driftr binary must be on PATH (set by caller)
+#   - install.sh must exist in the current directory
+#
+# Environment:
+#   TEST_SHELL  zsh | bash | fish | all (default: all)
+#
+# Run inside Dockerfile.path-e2e (Linux) or natively on macOS after:
+#   export PATH="/path/to/driftr-binary-dir:$PATH"
+#   sh test_path_e2e.sh
+
+set -eu
+
+pass=0
+fail_count=0
+
+ok() {
+    printf '[PASS] %s\n' "$1"
+    pass=$((pass + 1))
+}
+
+fail() {
+    printf '[FAIL] %s\n' "$1"
+    fail_count=$((fail_count + 1))
+}
+
+assert_cmd() {
+    desc="$1"; shift
+    if "$@" > /dev/null 2>&1; then
+        ok "$desc"
+    else
+        fail "$desc"
+    fi
+}
+
+assert_fail() {
+    desc="$1"; shift
+    if "$@" > /dev/null 2>&1; then
+        fail "$desc (expected failure, got success)"
+    else
+        ok "$desc"
+    fi
+}
+
+# ── setup ────────────────────────────────────────────────────────────────────
+
+INSTALL_DIR="$HOME/.driftr/bin"
+
+# Scrubbed PATH: excludes /usr/local/bin where the driftr binary lives in Docker.
+# Every PATH assertion must find the sentinel via the rc file only.
+CLEAN_PATH="/usr/bin:/usr/sbin:/bin:/sbin"
+
+printf 'driftr PATH e2e — shell: %s\n\n' "${TEST_SHELL:-all}"
+
+# Create ~/.driftr/bin and shims.
+driftr setup
+
+# Sentinel: a unique executable in ~/.driftr/bin that won't exist elsewhere.
+# Asserting 'command -v driftr-path-e2e-ok' proves the bin dir is on PATH via
+# the rc file — not via /usr/local/bin where the driftr binary lives in Docker.
+SENTINEL="driftr-path-e2e-ok"
+printf '#!/bin/sh\necho ok\n' > "$INSTALL_DIR/$SENTINEL"
+chmod +x "$INSTALL_DIR/$SENTINEL"
+
+# Patched install.sh: disable the 'main' call at the last line so we can source
+# just the function definitions and call configure_path() directly.
+# install.sh defines functions then calls main on line 240 as a bare word;
+# 'main() { :; }' before sourcing does not work because install.sh redefines
+# main() after our definition. sed-patch is the reliable approach.
+PATCHED_INSTALL=/tmp/install-path-test.sh
+sed 's/^main$/: # disabled by test/' install.sh > "$PATCHED_INSTALL"
+
+# Invoke configure_path for a given shell. Sets SHELL so detect_shell picks the
+# right rc file target, then sources the patched install.sh and calls the function.
+configure_path_for() {
+    shell_bin="$1"
+    (
+        export INSTALL_DIR
+        SHELL="$shell_bin"
+        export SHELL
+        # shellcheck source=install.sh
+        . "$PATCHED_INSTALL"
+        configure_path
+    )
+}
+
+# ── zsh ──────────────────────────────────────────────────────────────────────
+
+run_zsh_tests() {
+    ZSH_BIN=$(command -v zsh 2>/dev/null) || { printf '[SKIP] zsh not installed\n'; return; }
+    printf '\n[zsh]\n'
+
+    configure_path_for "$ZSH_BIN"
+
+    assert_cmd "zsh: .zshenv written" \
+        test -f "$HOME/.zshenv"
+    assert_cmd "zsh: .zshenv contains driftr bin dir" \
+        grep -qF "$INSTALL_DIR" "$HOME/.zshenv"
+
+    # No --no-rcs: tests that zsh auto-sources .zshenv on every invocation.
+    # That auto-sourcing behaviour is why .zshenv is the correct target.
+    assert_cmd "zsh: non-interactive invocation sources .zshenv" \
+        env -i HOME="$HOME" PATH="$CLEAN_PATH" \
+        zsh -c "command -v $SENTINEL"
+    assert_cmd "zsh: interactive invocation sources .zshenv" \
+        env -i HOME="$HOME" PATH="$CLEAN_PATH" \
+        zsh -i -c "command -v $SENTINEL"
+}
+
+# ── bash ─────────────────────────────────────────────────────────────────────
+
+run_bash_tests() {
+    BASH_BIN=$(command -v bash 2>/dev/null) || { printf '[SKIP] bash not installed\n'; return; }
+    printf '\n[bash]\n'
+
+    configure_path_for "$BASH_BIN"
+
+    assert_cmd "bash: .bash_profile written" \
+        test -f "$HOME/.bash_profile"
+    assert_cmd "bash: .bash_profile contains driftr bin dir" \
+        grep -qF "$INSTALL_DIR" "$HOME/.bash_profile"
+
+    assert_cmd "bash: login shell resolves driftr" \
+        env -i HOME="$HOME" PATH="$CLEAN_PATH" \
+        bash -l -c "command -v $SENTINEL"
+
+    # Non-interactive non-login bash does NOT read .bash_profile — documented
+    # limitation. Asserting the failure makes the contract executable and
+    # prevents accidental "fixes" that paper over the boundary.
+    assert_fail "bash: non-interactive non-login does not resolve driftr (expected)" \
+        env -i HOME="$HOME" PATH="$CLEAN_PATH" \
+        bash -c "command -v $SENTINEL"
+
+    # Non-interactive children of a login shell inherit PATH.
+    assert_cmd "bash: child of login shell inherits driftr on PATH" \
+        env -i HOME="$HOME" PATH="$CLEAN_PATH" \
+        bash -l -c "bash -c 'command -v $SENTINEL'"
+}
+
+# ── fish ─────────────────────────────────────────────────────────────────────
+
+run_fish_tests() {
+    FISH_BIN=$(command -v fish 2>/dev/null) || { printf '[SKIP] fish not installed\n'; return; }
+    printf '\n[fish]\n'
+
+    configure_path_for "$FISH_BIN"
+
+    FISH_CONF="${XDG_CONFIG_HOME:-$HOME/.config}/fish/conf.d/driftr.fish"
+    assert_cmd "fish: conf.d/driftr.fish written" \
+        test -f "$FISH_CONF"
+    assert_cmd "fish: driftr.fish contains set -gx PATH" \
+        grep -q 'set -gx PATH' "$FISH_CONF"
+
+    # fish sources conf.d on every invocation, interactive or not.
+    assert_cmd "fish: non-interactive invocation resolves driftr" \
+        env -i HOME="$HOME" PATH="$CLEAN_PATH" \
+        fish -c "command -v $SENTINEL"
+    assert_cmd "fish: type -q succeeds" \
+        env -i HOME="$HOME" PATH="$CLEAN_PATH" \
+        fish -c "type -q $SENTINEL"
+}
+
+# ── dispatch ─────────────────────────────────────────────────────────────────
+
+case "${TEST_SHELL:-all}" in
+    zsh)  run_zsh_tests ;;
+    bash) run_bash_tests ;;
+    fish) run_fish_tests ;;
+    all)
+        run_zsh_tests
+        run_bash_tests
+        run_fish_tests
+        ;;
+    *)
+        printf 'error: unknown TEST_SHELL=%s\n' "$TEST_SHELL" >&2
+        exit 1
+        ;;
+esac
+
+# ── summary ──────────────────────────────────────────────────────────────────
+
+printf '\n========================================\n'
+printf 'PATH e2e: %d passed, %d failed\n' "$pass" "$fail_count"
+printf '========================================\n'
+[ "$fail_count" -eq 0 ]

--- a/test_path_e2e.sh
+++ b/test_path_e2e.sh
@@ -1,194 +1,273 @@
 #!/bin/sh
-# PATH e2e tests — verify that install.sh configure_path() writes the correct
-# shell rc file and that a fresh shell subprocess with a scrubbed environment
-# finds driftr's bin dir on PATH automatically.
+# PATH + shim e2e tests.
+#
+# Phase 1 — PATH config: verify configure_path() writes the correct rc file
+#   and that a fresh shell subprocess with a scrubbed environment finds
+#   driftr's bin dir on PATH automatically.
+#
+# Phase 2 — Shim + version: install node@22, node@24, node@latest; verify
+#   node/npm/npx resolve correctly per global default and per-project pin
+#   (.driftr.toml and package.json), and that an uninstalled pin exits non-zero.
 #
 # Prerequisites:
-#   - driftr binary must be on PATH (set by caller)
+#   - driftr binary must be on PATH
 #   - install.sh must exist in the current directory
 #
 # Environment:
 #   TEST_SHELL  zsh | bash | fish | all (default: all)
-#
-# Run inside Dockerfile.path-e2e (Linux) or natively on macOS after:
-#   export PATH="/path/to/driftr-binary-dir:$PATH"
-#   sh test_path_e2e.sh
 
 set -eu
 
 pass=0
 fail_count=0
 
-ok() {
-    printf '[PASS] %s\n' "$1"
-    pass=$((pass + 1))
-}
-
-fail() {
-    printf '[FAIL] %s\n' "$1"
-    fail_count=$((fail_count + 1))
-}
+ok()   { printf '[PASS] %s\n' "$1"; pass=$((pass + 1)); }
+fail() { printf '[FAIL] %s\n' "$1"; fail_count=$((fail_count + 1)); }
 
 assert_cmd() {
     desc="$1"; shift
-    if "$@" > /dev/null 2>&1; then
-        ok "$desc"
-    else
-        fail "$desc"
-    fi
+    if "$@" > /dev/null 2>&1; then ok "$desc"; else fail "$desc"; fi
 }
 
 assert_fail() {
     desc="$1"; shift
-    if "$@" > /dev/null 2>&1; then
-        fail "$desc (expected failure, got success)"
-    else
-        ok "$desc"
-    fi
+    if "$@" > /dev/null 2>&1; then fail "$desc (expected failure, got success)"; else ok "$desc"; fi
 }
 
 # ── setup ────────────────────────────────────────────────────────────────────
 
 INSTALL_DIR="$HOME/.driftr/bin"
 
-# Scrubbed PATH: excludes /usr/local/bin where the driftr binary lives in Docker.
-# Every PATH assertion must find the sentinel via the rc file only.
+# Scrubbed PATH for zsh/bash env -i assertions: no /usr/local/bin (where the
+# driftr system binary lives in Docker). Used only for PATH-config assertions.
 CLEAN_PATH="/usr/bin:/usr/sbin:/bin:/sbin"
 
-printf 'driftr PATH e2e — shell: %s\n\n' "${TEST_SHELL:-all}"
+printf 'driftr PATH + shim e2e — shell: %s\n\n' "${TEST_SHELL:-all}"
 
-# Create ~/.driftr/bin and shims.
 driftr setup
 
-# Sentinel: a unique executable in ~/.driftr/bin that won't exist elsewhere.
-# Asserting 'command -v driftr-path-e2e-ok' proves the bin dir is on PATH via
-# the rc file — not via /usr/local/bin where the driftr binary lives in Docker.
+# Unique sentinel in ~/.driftr/bin — proves bin dir is on PATH via rc file,
+# not via /usr/local/bin where the driftr system binary is in Docker.
 SENTINEL="driftr-path-e2e-ok"
 printf '#!/bin/sh\necho ok\n' > "$INSTALL_DIR/$SENTINEL"
 chmod +x "$INSTALL_DIR/$SENTINEL"
 
-# Patched install.sh: disable the 'main' call at the last line so we can source
-# just the function definitions and call configure_path() directly.
-# install.sh defines functions then calls main on line 240 as a bare word;
-# 'main() { :; }' before sourcing does not work because install.sh redefines
-# main() after our definition. sed-patch is the reliable approach.
+# Patch install.sh: disable the bare 'main' call at the last line so we can
+# source function definitions and call configure_path() directly.
+# Pre-defining main() { :; } before sourcing does NOT work — install.sh
+# redefines main() after our definition, overriding the no-op.
 PATCHED_INSTALL=/tmp/install-path-test.sh
 sed 's/^main$/: # disabled by test/' install.sh > "$PATCHED_INSTALL"
 
-# Invoke configure_path for a given shell. Sets SHELL so detect_shell picks the
-# right rc file target, then sources the patched install.sh and calls the function.
 configure_path_for() {
     shell_bin="$1"
     (
         export INSTALL_DIR
         SHELL="$shell_bin"
         export SHELL
-        # shellcheck source=install.sh
         . "$PATCHED_INSTALL"
         configure_path
     )
 }
 
-# ── zsh ──────────────────────────────────────────────────────────────────────
+# ── shell execution helpers (phase 2) ────────────────────────────────────────
 
-run_zsh_tests() {
+# PATH for shim-execution assertions: includes driftr binary dir (needed by
+# shim scripts that exec 'driftr shim <tool>') but NOT the install dir.
+# For fish we strip install dir from the full PATH instead of using env -i,
+# because fish 4.x (Rust) needs HOME/TMPDIR/USER/XDG_DATA_DIRS to start.
+DRIFTR_DIR="$(dirname "$(command -v driftr)")"
+SHIM_CLEAN_PATH="${DRIFTR_DIR}:/usr/bin:/usr/sbin:/bin:/sbin"
+PATH_NO_INSTALL="$(printf '%s' "$PATH" | tr ':' '\n' | grep -vF "$INSTALL_DIR" | tr '\n' ':' | sed 's/:$//')"
+
+# shell_exec SHELL CMD — run CMD in a fresh shell with controlled PATH.
+# The rc file (zshenv / bash_profile / fish conf.d) adds INSTALL_DIR on top.
+shell_exec() {
+    _sh="$1"; _cmd="$2"
+    case "$_sh" in
+        zsh)  env -i HOME="$HOME" PATH="$SHIM_CLEAN_PATH" zsh    -c "$_cmd" ;;
+        bash) env -i HOME="$HOME" PATH="$SHIM_CLEAN_PATH" bash -l -c "$_cmd" ;;
+        fish) env PATH="$PATH_NO_INSTALL" fish -c "$_cmd" ;;
+        *)    return 1 ;;
+    esac
+}
+
+assert_shell() {
+    _desc="$1"; _sh="$2"; _cmd="$3"
+    if shell_exec "$_sh" "$_cmd" > /dev/null 2>&1; then ok "$_desc"; else fail "$_desc"; fi
+}
+
+assert_shell_output() {
+    _desc="$1"; _sh="$2"; _cmd="$3"; _pat="$4"
+    _out=$(shell_exec "$_sh" "$_cmd" 2>&1) || true
+    if printf '%s\n' "$_out" | grep -q "$_pat"; then
+        ok "$_desc"
+    else
+        fail "$_desc (got: $_out)"
+    fi
+}
+
+assert_shell_fail() {
+    _desc="$1"; _sh="$2"; _cmd="$3"
+    if shell_exec "$_sh" "$_cmd" > /dev/null 2>&1; then
+        fail "$_desc (expected failure, got success)"
+    else
+        ok "$_desc"
+    fi
+}
+
+# ── phase 1: PATH config ─────────────────────────────────────────────────────
+
+run_path_tests_zsh() {
     ZSH_BIN=$(command -v zsh 2>/dev/null) || { printf '[SKIP] zsh not installed\n'; return; }
-    printf '\n[zsh]\n'
-
+    printf '\n[PATH config — zsh]\n'
     configure_path_for "$ZSH_BIN"
-
-    assert_cmd "zsh: .zshenv written" \
-        test -f "$HOME/.zshenv"
-    assert_cmd "zsh: .zshenv contains driftr bin dir" \
-        grep -qF "$INSTALL_DIR" "$HOME/.zshenv"
-
-    # No --no-rcs: tests that zsh auto-sources .zshenv on every invocation.
-    # That auto-sourcing behaviour is why .zshenv is the correct target.
-    assert_cmd "zsh: non-interactive invocation sources .zshenv" \
-        env -i HOME="$HOME" PATH="$CLEAN_PATH" \
-        zsh -c "command -v $SENTINEL"
-    assert_cmd "zsh: interactive invocation sources .zshenv" \
-        env -i HOME="$HOME" PATH="$CLEAN_PATH" \
-        zsh -i -c "command -v $SENTINEL"
+    assert_cmd "zsh: .zshenv written"              test -f "$HOME/.zshenv"
+    assert_cmd "zsh: .zshenv contains bin dir"     grep -qF "$INSTALL_DIR" "$HOME/.zshenv"
+    # No --no-rcs: verifies zsh auto-sources .zshenv on every invocation.
+    assert_cmd "zsh: non-interactive sources .zshenv" \
+        env -i HOME="$HOME" PATH="$CLEAN_PATH" zsh -c "command -v $SENTINEL"
+    assert_cmd "zsh: interactive sources .zshenv" \
+        env -i HOME="$HOME" PATH="$CLEAN_PATH" zsh -i -c "command -v $SENTINEL"
 }
 
-# ── bash ─────────────────────────────────────────────────────────────────────
-
-run_bash_tests() {
+run_path_tests_bash() {
     BASH_BIN=$(command -v bash 2>/dev/null) || { printf '[SKIP] bash not installed\n'; return; }
-    printf '\n[bash]\n'
-
+    printf '\n[PATH config — bash]\n'
     configure_path_for "$BASH_BIN"
-
-    assert_cmd "bash: .bash_profile written" \
-        test -f "$HOME/.bash_profile"
-    assert_cmd "bash: .bash_profile contains driftr bin dir" \
-        grep -qF "$INSTALL_DIR" "$HOME/.bash_profile"
-
-    assert_cmd "bash: login shell resolves driftr" \
-        env -i HOME="$HOME" PATH="$CLEAN_PATH" \
-        bash -l -c "command -v $SENTINEL"
-
-    # Non-interactive non-login bash does NOT read .bash_profile — documented
-    # limitation. Asserting the failure makes the contract executable and
-    # prevents accidental "fixes" that paper over the boundary.
-    assert_fail "bash: non-interactive non-login does not resolve driftr (expected)" \
-        env -i HOME="$HOME" PATH="$CLEAN_PATH" \
-        bash -c "command -v $SENTINEL"
-
-    # Non-interactive children of a login shell inherit PATH.
-    assert_cmd "bash: child of login shell inherits driftr on PATH" \
-        env -i HOME="$HOME" PATH="$CLEAN_PATH" \
-        bash -l -c "bash -c 'command -v $SENTINEL'"
+    assert_cmd "bash: .bash_profile written"           test -f "$HOME/.bash_profile"
+    assert_cmd "bash: .bash_profile contains bin dir"  grep -qF "$INSTALL_DIR" "$HOME/.bash_profile"
+    assert_cmd "bash: login shell resolves sentinel" \
+        env -i HOME="$HOME" PATH="$CLEAN_PATH" bash -l -c "command -v $SENTINEL"
+    # Non-interactive non-login bash does not read .bash_profile — documented
+    # limitation. The assert_fail makes the contract executable.
+    assert_fail "bash: non-interactive non-login does not resolve (expected)" \
+        env -i HOME="$HOME" PATH="$CLEAN_PATH" bash -c "command -v $SENTINEL"
+    assert_cmd "bash: child of login shell inherits PATH" \
+        env -i HOME="$HOME" PATH="$CLEAN_PATH" bash -l -c "bash -c 'command -v $SENTINEL'"
 }
 
-# ── fish ─────────────────────────────────────────────────────────────────────
-
-run_fish_tests() {
+run_path_tests_fish() {
     FISH_BIN=$(command -v fish 2>/dev/null) || { printf '[SKIP] fish not installed\n'; return; }
-    printf '\n[fish]\n'
-
+    printf '\n[PATH config — fish]\n'
     configure_path_for "$FISH_BIN"
-
     FISH_CONF="${XDG_CONFIG_HOME:-$HOME/.config}/fish/conf.d/driftr.fish"
-    assert_cmd "fish: conf.d/driftr.fish written" \
-        test -f "$FISH_CONF"
-    assert_cmd "fish: driftr.fish contains set -gx PATH" \
-        grep -q 'set -gx PATH' "$FISH_CONF"
-
-    # fish sources conf.d on every invocation, interactive or not.
-    # env -i is too aggressive for fish 4.x (Rust rewrite): it needs HOME,
-    # TMPDIR, USER, and potentially XDG_DATA_DIRS to start cleanly. Instead,
-    # strip only the install dir from PATH — same property, less fragile.
-    PATH_WITHOUT_INSTALL="$(echo "$PATH" | tr ':' '\n' | grep -vF "$INSTALL_DIR" | tr '\n' ':' | sed 's/:$//')"
-    assert_cmd "fish: non-interactive invocation sources conf.d" \
-        env PATH="$PATH_WITHOUT_INSTALL" \
-        fish -c "command -v $SENTINEL"
+    assert_cmd "fish: conf.d/driftr.fish written"       test -f "$FISH_CONF"
+    assert_cmd "fish: driftr.fish contains set -gx PATH" grep -q 'set -gx PATH' "$FISH_CONF"
+    # fish 4.x needs HOME/TMPDIR/USER: use PATH stripping rather than env -i.
+    PATH_WITHOUT_INSTALL="$(printf '%s' "$PATH" | tr ':' '\n' | grep -vF "$INSTALL_DIR" | tr '\n' ':' | sed 's/:$//')"
+    assert_cmd "fish: non-interactive sources conf.d" \
+        env PATH="$PATH_WITHOUT_INSTALL" fish -c "command -v $SENTINEL"
     assert_cmd "fish: type -q succeeds" \
-        env PATH="$PATH_WITHOUT_INSTALL" \
-        fish -c "type -q $SENTINEL"
+        env PATH="$PATH_WITHOUT_INSTALL" fish -c "type -q $SENTINEL"
+}
+
+# ── phase 2: node version install ────────────────────────────────────────────
+
+NODE22_FULL=""
+NODE24_FULL=""
+
+install_node_versions() {
+    printf '\n[node install — 22, 24, latest]\n'
+    driftr install node@22
+    driftr install node@24
+    driftr install node@latest
+
+    # Capture exact installed full versions for deterministic pin tests.
+    # 'driftr which node' outputs the binary path; extract semver from it.
+    # Resolving the partial pin at test-time against the release index risks
+    # mismatches if a newer patch is published between install and pin-check.
+    driftr default node@22
+    NODE22_FULL="$(driftr which node 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+    driftr default node@24
+    NODE24_FULL="$(driftr which node 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+
+    printf 'node versions ready (22=%s, 24=%s)\n' "$NODE22_FULL" "$NODE24_FULL"
+}
+
+# ── phase 2: shim + pin + auto-install tests per shell ───────────────────────
+
+run_shim_tests() {
+    _sh="$1"
+    printf '\n[shim + pin — %s]\n' "$_sh"
+
+    # global default node@22
+    driftr default node@22
+    assert_shell_output "$_sh: node@22 global — node -v"  "$_sh" 'node -v'        '^v22\.'
+    assert_shell        "$_sh: node@22 global — npm -v"   "$_sh" 'npm -v'
+    assert_shell        "$_sh: node@22 global — npx -v"   "$_sh" 'npx --version'
+
+    # global default node@24
+    driftr default node@24
+    assert_shell_output "$_sh: node@24 global — node -v"  "$_sh" 'node -v'        '^v24\.'
+
+    # global default node@latest
+    driftr default node@latest
+    assert_shell_output "$_sh: node@latest global — node -v" "$_sh" 'node -v'     '^v[0-9]'
+
+    # pin via .driftr.toml overrides global (global=latest, pin=exact 22.x)
+    # Use the full version captured at install time — partial version "22" in
+    # the pin risks a resolver mismatch if a newer 22.x patch is published
+    # between install and pin-check.
+    _p1="$(mktemp -d)"
+    printf '[tools]\nnode = "%s"\n' "$NODE22_FULL" > "$_p1/.driftr.toml"
+    assert_shell_output "$_sh: .driftr.toml pin overrides global" \
+        "$_sh" "cd '$_p1' && node -v" "^v${NODE22_FULL}$"
+    rm -rf "$_p1"
+
+    # pin via package.json driftr key (global=latest, pin=exact 24.x)
+    _p2="$(mktemp -d)"
+    printf '{"driftr":{"node":"%s"}}\n' "$NODE24_FULL" > "$_p2/package.json"
+    assert_shell_output "$_sh: package.json pin overrides global" \
+        "$_sh" "cd '$_p2' && node -v" "^v${NODE24_FULL}$"
+    rm -rf "$_p2"
+
+    # auto-install: pin version that is not installed — shim must exit non-zero.
+    # node@18 is not installed (we only installed 22, 24, latest).
+    _p3="$(mktemp -d)"
+    printf '[tools]\nnode = "18"\n' > "$_p3/.driftr.toml"
+    assert_shell_fail "$_sh: uninstalled pin exits non-zero (node@18)" \
+        "$_sh" "cd '$_p3' && node -v"
+    rm -rf "$_p3"
 }
 
 # ── dispatch ─────────────────────────────────────────────────────────────────
 
+for_each_active_shell() {
+    _fn="$1"
+    case "${TEST_SHELL:-all}" in
+        zsh)  command -v zsh  > /dev/null 2>&1 && "$_fn" zsh  || printf '[SKIP] zsh not installed\n' ;;
+        bash) command -v bash > /dev/null 2>&1 && "$_fn" bash || printf '[SKIP] bash not installed\n' ;;
+        fish) command -v fish > /dev/null 2>&1 && "$_fn" fish || printf '[SKIP] fish not installed\n' ;;
+        all)
+            command -v zsh  > /dev/null 2>&1 && "$_fn" zsh  || true
+            command -v bash > /dev/null 2>&1 && "$_fn" bash || true
+            command -v fish > /dev/null 2>&1 && "$_fn" fish || true
+            ;;
+        *) printf 'error: unknown TEST_SHELL=%s\n' "$TEST_SHELL" >&2; exit 1 ;;
+    esac
+}
+
+printf '\n════════════════ PHASE 1: PATH CONFIG ════════════════\n'
 case "${TEST_SHELL:-all}" in
-    zsh)  run_zsh_tests ;;
-    bash) run_bash_tests ;;
-    fish) run_fish_tests ;;
+    zsh)  run_path_tests_zsh ;;
+    bash) run_path_tests_bash ;;
+    fish) run_path_tests_fish ;;
     all)
-        run_zsh_tests
-        run_bash_tests
-        run_fish_tests
+        run_path_tests_zsh
+        run_path_tests_bash
+        run_path_tests_fish
         ;;
-    *)
-        printf 'error: unknown TEST_SHELL=%s\n' "$TEST_SHELL" >&2
-        exit 1
-        ;;
+    *) printf 'error: unknown TEST_SHELL=%s\n' "$TEST_SHELL" >&2; exit 1 ;;
 esac
+
+printf '\n════════════════ PHASE 2: SHIM + VERSION ════════════════\n'
+install_node_versions
+for_each_active_shell run_shim_tests
 
 # ── summary ──────────────────────────────────────────────────────────────────
 
 printf '\n========================================\n'
-printf 'PATH e2e: %d passed, %d failed\n' "$pass" "$fail_count"
+printf 'PATH + shim e2e: %d passed, %d failed\n' "$pass" "$fail_count"
 printf '========================================\n'
 [ "$fail_count" -eq 0 ]

--- a/test_path_e2e.sh
+++ b/test_path_e2e.sh
@@ -262,8 +262,15 @@ case "${TEST_SHELL:-all}" in
 esac
 
 printf '\n════════════════ PHASE 2: SHIM + VERSION ════════════════\n'
-install_node_versions
-for_each_active_shell run_shim_tests
+if [ "${SKIP_SHIM_TESTS:-0}" = "1" ]; then
+    # Node.js official binaries are glibc-only and do not run on musl libc.
+    # Phase 1 already proves driftr itself works on musl. Phase 2 is skipped
+    # on Alpine so the musl-compat job does not fail on a Node.js limitation.
+    printf '[SKIP] Phase 2 skipped — Node.js glibc binaries incompatible with musl\n'
+else
+    install_node_versions
+    for_each_active_shell run_shim_tests
+fi
 
 # ── summary ──────────────────────────────────────────────────────────────────
 

--- a/test_path_e2e.sh
+++ b/test_path_e2e.sh
@@ -116,19 +116,33 @@ assert_shell_fail() {
     fi
 }
 
+# cd_then SHELL DIR CMD — build a shell-appropriate "cd DIR && CMD" string.
+# fish does not support && for chaining (pre-3.0) — use '; and' instead.
+# fish 3.0+ supports && but '; and' works across all fish versions.
+cd_then() { _csh="$1"; _dir="$2"; _c="$3"
+    if [ "$_csh" = "fish" ]; then printf "cd '%s'; and %s" "$_dir" "$_c"
+    else                           printf "cd '%s' && %s"  "$_dir" "$_c"
+    fi
+}
+
 # ── phase 1: PATH config ─────────────────────────────────────────────────────
 
 run_path_tests_zsh() {
     ZSH_BIN=$(command -v zsh 2>/dev/null) || { printf '[SKIP] zsh not installed\n'; return; }
     printf '\n[PATH config — zsh]\n'
+    # configure_path() uses ${ZDOTDIR:-$HOME}/.zshenv. Pin ZDOTDIR=HOME so the
+    # assertion checks the same file that configure_path wrote to, even if the
+    # runner environment has ZDOTDIR set to something else.
+    ZDOTDIR="$HOME"; export ZDOTDIR
+    ZSHENV_PATH="$ZDOTDIR/.zshenv"
     configure_path_for "$ZSH_BIN"
-    assert_cmd "zsh: .zshenv written"              test -f "$HOME/.zshenv"
-    assert_cmd "zsh: .zshenv contains bin dir"     grep -qF "$INSTALL_DIR" "$HOME/.zshenv"
+    assert_cmd "zsh: .zshenv written"              test -f "$ZSHENV_PATH"
+    assert_cmd "zsh: .zshenv contains bin dir"     grep -qF "$INSTALL_DIR" "$ZSHENV_PATH"
     # No --no-rcs: verifies zsh auto-sources .zshenv on every invocation.
     assert_cmd "zsh: non-interactive sources .zshenv" \
-        env -i HOME="$HOME" PATH="$CLEAN_PATH" zsh -c "command -v $SENTINEL"
+        env -i HOME="$HOME" ZDOTDIR="$ZDOTDIR" PATH="$CLEAN_PATH" zsh -c "command -v $SENTINEL"
     assert_cmd "zsh: interactive sources .zshenv" \
-        env -i HOME="$HOME" PATH="$CLEAN_PATH" zsh -i -c "command -v $SENTINEL"
+        env -i HOME="$HOME" ZDOTDIR="$ZDOTDIR" PATH="$CLEAN_PATH" zsh -i -c "command -v $SENTINEL"
 }
 
 run_path_tests_bash() {
@@ -182,6 +196,8 @@ install_node_versions() {
     driftr default node@24
     NODE24_FULL="$(driftr which node 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
 
+    [ -n "$NODE22_FULL" ] || { printf '[FAIL] could not determine full version for node@22\n' >&2; exit 1; }
+    [ -n "$NODE24_FULL" ] || { printf '[FAIL] could not determine full version for node@24\n' >&2; exit 1; }
     printf 'node versions ready (22=%s, 24=%s)\n' "$NODE22_FULL" "$NODE24_FULL"
 }
 
@@ -212,14 +228,14 @@ run_shim_tests() {
     _p1="$(mktemp -d)"
     printf '[tools]\nnode = "%s"\n' "$NODE22_FULL" > "$_p1/.driftr.toml"
     assert_shell_output "$_sh: .driftr.toml pin overrides global" \
-        "$_sh" "cd '$_p1' && node -v" "^v${NODE22_FULL}$"
+        "$_sh" "$(cd_then "$_sh" "$_p1" 'node -v')" "^v${NODE22_FULL}$"
     rm -rf "$_p1"
 
     # pin via package.json driftr key (global=latest, pin=exact 24.x)
     _p2="$(mktemp -d)"
     printf '{"driftr":{"node":"%s"}}\n' "$NODE24_FULL" > "$_p2/package.json"
     assert_shell_output "$_sh: package.json pin overrides global" \
-        "$_sh" "cd '$_p2' && node -v" "^v${NODE24_FULL}$"
+        "$_sh" "$(cd_then "$_sh" "$_p2" 'node -v')" "^v${NODE24_FULL}$"
     rm -rf "$_p2"
 
     # auto-install: pin version that is not installed — shim must exit non-zero.
@@ -227,7 +243,7 @@ run_shim_tests() {
     _p3="$(mktemp -d)"
     printf '[tools]\nnode = "18"\n' > "$_p3/.driftr.toml"
     assert_shell_fail "$_sh: uninstalled pin exits non-zero (node@18)" \
-        "$_sh" "cd '$_p3' && node -v"
+        "$_sh" "$(cd_then "$_sh" "$_p3" 'node -v')"
     rm -rf "$_p3"
 }
 


### PR DESCRIPTION
## Summary

- New `test_path_e2e.sh` (POSIX sh) runs in two phases across all active shells (zsh, bash, fish)
- Single `Dockerfile.path-e2e` with ARG parameterization — no separate Dockerfiles, no docker-compose
- 5 new parallel CI jobs gated on unit tests passing

| Job | Image | Shell(s) |
|-----|-------|----------|
| PATH e2e (zsh) | debian:bookworm-slim | zsh — `.zshenv` auto-sourcing |
| PATH e2e (bash) | debian:bookworm-slim | bash — `.bash_profile` login; non-interactive limitation asserted |
| PATH e2e (fish) | debian:bookworm-slim | fish — `conf.d` auto-sourcing |
| PATH e2e (alpine/musl) | alpine:3.21 | bash — also tests musl libc compat |
| PATH e2e (macOS) | macos-latest (native) | zsh + bash + fish |

## Phase 1 — PATH config

Verifies `configure_path()` writes the correct rc file per shell and that a fresh subprocess with scrubbed PATH finds the driftr bin dir via that file alone (not via inherited PATH).

## Phase 2 — Shim + version

Installs node@22, node@24, and node@latest, then for each active shell:
- `node -v`, `npm -v`, `npx --version` resolve correctly per global default
- `.driftr.toml` pin overrides global default
- `package.json` driftr key pin overrides global default
- Uninstalled pin exits non-zero (auto-install guard)

## Key design notes

- `env -i` scrubs inherited `$PATH`; unique sentinel `driftr-path-e2e-ok` in `~/.driftr/bin/` prevents false passes from `/usr/local/bin/driftr`
- fish 4.x (Rust rewrite) fails with `env -i` — uses selective PATH stripping instead
- bash non-interactive limitation asserted as `assert_fail` — executable documentation of the architectural boundary
- `sed 's/^main$/: # disabled/' install.sh` isolates `configure_path()` without triggering network download
- Pin tests use exact version from `driftr which node | head -1` — avoids race with partial version resolving to a newer patch than installed
- `libatomic1` added to Debian install — required by Node.js 25.x on ARM64