### PR TITLE
feat(list): colorize output with active/default/dim markers

### DIFF
--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/DriftrLabs/driftr/internal/config"
 	"github.com/DriftrLabs/driftr/internal/installer"
+	"github.com/DriftrLabs/driftr/internal/ioutil"
+	"github.com/DriftrLabs/driftr/internal/resolver"
 )
 
 func newListCmd() *cobra.Command {
@@ -40,17 +42,51 @@ func newListCmd() *cobra.Command {
 
 			defaultVer := cfg.Default.GetTool(tool)
 
-			fmt.Printf("Installed %s versions:\n", tool)
-			for _, v := range versions {
-				marker := "  "
-				if v == defaultVer {
-					marker = "* "
-				}
-				fmt.Printf("  %s%s\n", marker, v)
+			res, _ := resolver.ResolveTool(tool, "", false)
+			activeVer := ""
+			if res != nil {
+				activeVer = res.Version
 			}
 
+			fmt.Printf("Installed %s versions:\n", tool)
+			for _, v := range versions {
+				isActive := activeVer != "" && v == activeVer
+				isDefault := defaultVer != "" && v == defaultVer
+
+				activeMark := " "
+				if isActive {
+					activeMark = ">"
+				}
+				defaultMark := " "
+				if isDefault {
+					defaultMark = "*"
+				}
+				line := activeMark + defaultMark + " " + v
+
+				switch {
+				case isActive && isDefault:
+					line = ioutil.Green(ioutil.Bold(line))
+				case isActive:
+					line = ioutil.Green(line)
+				case !isActive && !isDefault:
+					line = ioutil.Dim(line)
+				}
+
+				fmt.Printf("  %s\n", line)
+			}
+
+			var legend []string
+			if activeVer != "" {
+				legend = append(legend, "  > = active (current directory)")
+			}
 			if defaultVer != "" {
-				fmt.Printf("\n  * = global default\n")
+				legend = append(legend, "  * = global default")
+			}
+			if len(legend) > 0 {
+				fmt.Println()
+				for _, l := range legend {
+					fmt.Println(l)
+				}
 			}
 
 			return nil

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -42,10 +44,12 @@ func newListCmd() *cobra.Command {
 
 			defaultVer := cfg.Default.GetTool(tool)
 
-			res, _ := resolver.ResolveTool(tool, "", false)
+			res, resolveErr := resolver.ResolveTool(tool, "", false)
 			activeVer := ""
-			if res != nil {
+			if resolveErr == nil && res != nil {
 				activeVer = res.Version
+			} else if resolveErr != nil && !strings.HasPrefix(resolveErr.Error(), "no "+tool+" version configured") {
+				fmt.Fprintf(os.Stderr, "warning: could not determine active %s version: %v\n", tool, resolveErr)
 			}
 
 			fmt.Printf("Installed %s versions:\n", tool)

--- a/internal/ioutil/color.go
+++ b/internal/ioutil/color.go
@@ -1,12 +1,21 @@
 package ioutil
 
-import "os"
+import (
+	"os"
+	"sync"
+)
+
+var (
+	ttyOnce sync.Once
+	isTTY   bool
+)
 
 func colorEnabled() bool {
 	if os.Getenv("NO_COLOR") != "" {
 		return false
 	}
-	return IsTerminal(os.Stdout)
+	ttyOnce.Do(func() { isTTY = IsTerminal(os.Stdout) })
+	return isTTY
 }
 
 func colorize(s, ansiCode string) string {

--- a/internal/ioutil/color.go
+++ b/internal/ioutil/color.go
@@ -1,0 +1,35 @@
+package ioutil
+
+import "os"
+
+func colorEnabled() bool {
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	return IsTerminal(os.Stdout)
+}
+
+func colorize(s, ansiCode string) string {
+	return "\033[" + ansiCode + "m" + s + "\033[0m"
+}
+
+func Green(s string) string {
+	if !colorEnabled() {
+		return s
+	}
+	return colorize(s, "32")
+}
+
+func Bold(s string) string {
+	if !colorEnabled() {
+		return s
+	}
+	return colorize(s, "1")
+}
+
+func Dim(s string) string {
+	if !colorEnabled() {
+		return s
+	}
+	return colorize(s, "2")
+}

--- a/internal/ioutil/color_test.go
+++ b/internal/ioutil/color_test.go
@@ -3,8 +3,15 @@ package ioutil
 import (
 	"os"
 	"strings"
+	"sync"
 	"testing"
 )
+
+// resetColorCache resets the memoized TTY state so tests get a clean slate.
+func resetColorCache() {
+	ttyOnce = sync.Once{}
+	isTTY = false
+}
 
 func TestColorize_AppliesANSI(t *testing.T) {
 	got := colorize("hello", "32")
@@ -28,8 +35,31 @@ func TestColorDisabled_NO_COLOR(t *testing.T) {
 }
 
 func TestColorDisabled_NonTTY(t *testing.T) {
-	// Tests always run with stdout as a pipe (non-TTY).
+	// Reset cached TTY state so this test controls when it fires.
+	resetColorCache()
+	t.Cleanup(resetColorCache)
+
+	// Guarantee non-TTY stdout via a pipe, regardless of test runner environment.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := os.Stdout
+	os.Stdout = w
+	t.Cleanup(func() {
+		os.Stdout = old
+		r.Close()
+		w.Close()
+	})
+
+	// Ensure NO_COLOR is unset so we test TTY detection, not the NO_COLOR path.
+	prev, prevOK := os.LookupEnv("NO_COLOR")
 	os.Unsetenv("NO_COLOR")
+	t.Cleanup(func() {
+		if prevOK {
+			os.Setenv("NO_COLOR", prev)
+		}
+	})
 
 	if strings.Contains(Green("x"), "\033") {
 		t.Error("Green() should not emit ANSI codes when stdout is not a TTY")

--- a/internal/ioutil/color_test.go
+++ b/internal/ioutil/color_test.go
@@ -1,0 +1,43 @@
+package ioutil
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestColorize_AppliesANSI(t *testing.T) {
+	got := colorize("hello", "32")
+	if got != "\033[32mhello\033[0m" {
+		t.Errorf("colorize() = %q, want ANSI-wrapped string", got)
+	}
+}
+
+func TestColorDisabled_NO_COLOR(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+
+	if Green("x") != "x" {
+		t.Error("Green() should return plain text when NO_COLOR is set")
+	}
+	if Bold("x") != "x" {
+		t.Error("Bold() should return plain text when NO_COLOR is set")
+	}
+	if Dim("x") != "x" {
+		t.Error("Dim() should return plain text when NO_COLOR is set")
+	}
+}
+
+func TestColorDisabled_NonTTY(t *testing.T) {
+	// Tests always run with stdout as a pipe (non-TTY).
+	os.Unsetenv("NO_COLOR")
+
+	if strings.Contains(Green("x"), "\033") {
+		t.Error("Green() should not emit ANSI codes when stdout is not a TTY")
+	}
+	if strings.Contains(Bold("x"), "\033") {
+		t.Error("Bold() should not emit ANSI codes when stdout is not a TTY")
+	}
+	if strings.Contains(Dim("x"), "\033") {
+		t.Error("Dim() should not emit ANSI codes when stdout is not a TTY")
+	}
+}


### PR DESCRIPTION
## Summary

- `>` marker (green) for version active in current directory
- `*` marker for global default; `>*` when both
- Dimmed text for versions that are neither active nor default
- Respects `NO_COLOR` env var; no color when stdout is not a TTY
- No new dependencies — ANSI helpers use stdlib only

Closes #44