### PR TITLE
feat(list): remote version browsing with --remote flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ pnpm -v   # resolves automatically
 | `driftr default <tool@version>` | Set the global default version for a tool |
 | `driftr pin <tool@version>` | Pin a version to the current project (`.driftr.toml` or `package.json`) |
 | `driftr list [tool]` | List installed versions (defaults to node) |
+| `driftr list --remote [tool]` | Browse available remote versions from nodejs.org / npm registry |
 | `driftr which <tool>` | Show which binary would be executed and why |
 | `driftr run --node <ver> -- <cmd>` | Run a command under a specific Node.js version |
 | `driftr setup` | Initialize Driftr and generate shims |
@@ -77,6 +78,17 @@ pnpm -v   # resolves automatically
 | `driftr doctor [--fix]` | Check your Driftr installation for common problems |
 
 All commands support `-v` / `--verbose` for detailed output including resolver tracing and checksum details.
+
+### Remote version listing flags
+
+```bash
+driftr list --remote [tool]          # Show available versions (default: latest 30)
+driftr list --remote --limit 10      # Limit output to 10 versions
+driftr list --remote --limit 0       # Show all versions (can be 500+ for node)
+driftr list --remote --pre pnpm      # Include pre-release versions (npm packages only)
+```
+
+Installed versions are marked with `●`, the active version with `>`, and the global default with `*`. Node.js LTS releases show their codename (e.g. `LTS: Jod`).
 
 ## Shell Completions
 

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -13,17 +13,32 @@ import (
 	"github.com/DriftrLabs/driftr/internal/resolver"
 )
 
+// npmPackage maps tool names to their npm package names.
+// Tools not in this map are not listable from the npm registry.
+var npmPackage = map[string]string{
+	"pnpm": "pnpm",
+	"yarn": "yarn",
+}
+
 func newListCmd() *cobra.Command {
-	return &cobra.Command{
+	var remote bool
+	var pre bool
+	var limit int
+
+	cmd := &cobra.Command{
 		Use:     "list [tool]",
 		Aliases: []string{"ls"},
 		Short:   "List installed versions",
-		Long:    "List installed versions for a tool. Defaults to node.\n\nExamples:\n  driftr list\n  driftr list node",
+		Long:    "List installed versions for a tool. Defaults to node.\n\nExamples:\n  driftr list\n  driftr list node\n  driftr list --remote node\n  driftr list --remote pnpm --pre\n  driftr list --remote node --limit 10",
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			tool := "node"
 			if len(args) > 0 {
 				tool = args[0]
+			}
+
+			if remote {
+				return listRemote(tool, pre, limit)
 			}
 
 			versions, err := installer.ListInstalledToolVersions(tool)
@@ -96,4 +111,159 @@ func newListCmd() *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().BoolVar(&remote, "remote", false, "List available remote versions")
+	cmd.Flags().BoolVar(&pre, "pre", false, "Include pre-release versions (npm packages only)")
+	cmd.Flags().IntVar(&limit, "limit", 30, "Max versions to show (0 = all)")
+
+	return cmd
+}
+
+func listRemote(tool string, includePre bool, limit int) error {
+	installedVers, err := installer.ListInstalledToolVersions(tool)
+	if err != nil {
+		return fmt.Errorf("failed to list installed versions: %w", err)
+	}
+	installed := make(map[string]bool, len(installedVers))
+	for _, v := range installedVers {
+		installed[v] = true
+	}
+
+	cfg, _ := config.LoadGlobal()
+	defaultVer := ""
+	if cfg != nil {
+		defaultVer = cfg.Default.GetTool(tool)
+	}
+
+	res, _ := resolver.ResolveTool(tool, "", false)
+	activeVer := ""
+	if res != nil {
+		activeVer = res.Version
+	}
+
+	if tool == "node" {
+		return listRemoteNode(limit, installed, activeVer, defaultVer)
+	}
+
+	pkg, ok := npmPackage[tool]
+	if !ok {
+		supported := []string{"node"}
+		for k := range npmPackage {
+			supported = append(supported, k)
+		}
+		return fmt.Errorf("remote listing not supported for %q (supported: %s)", tool, strings.Join(supported, ", "))
+	}
+
+	return listRemoteNpm(pkg, tool, includePre, limit, installed, activeVer, defaultVer)
+}
+
+func listRemoteNode(limit int, installed map[string]bool, activeVer, defaultVer string) error {
+	releases, err := installer.FetchNodeIndex()
+	if err != nil {
+		return fmt.Errorf("failed to fetch Node.js release list: %w", err)
+	}
+
+	total := len(releases)
+	if limit > 0 && len(releases) > limit {
+		releases = releases[:limit]
+	}
+
+	header := fmt.Sprintf("Available node versions (latest %d of %d):", len(releases), total)
+	if limit == 0 {
+		header = fmt.Sprintf("Available node versions (all %d):", total)
+	}
+	fmt.Println(header)
+
+	for _, rel := range releases {
+		printRemoteVersion(rel.Version, ltsCodename(rel.LTS), installed, activeVer, defaultVer)
+	}
+
+	printRemoteLegend(activeVer, defaultVer)
+	return nil
+}
+
+func listRemoteNpm(pkg, tool string, includePre bool, limit int, installed map[string]bool, activeVer, defaultVer string) error {
+	versions, err := installer.ListRemoteVersions(pkg, includePre)
+	if err != nil {
+		return fmt.Errorf("failed to fetch %s versions: %w", tool, err)
+	}
+
+	total := len(versions)
+	if limit > 0 && len(versions) > limit {
+		versions = versions[:limit]
+	}
+
+	header := fmt.Sprintf("Available %s versions (latest %d of %d):", tool, len(versions), total)
+	if limit == 0 {
+		header = fmt.Sprintf("Available %s versions (all %d):", tool, total)
+	}
+	fmt.Println(header)
+
+	for _, v := range versions {
+		printRemoteVersion(v, "", installed, activeVer, defaultVer)
+	}
+
+	printRemoteLegend(activeVer, defaultVer)
+	return nil
+}
+
+// printRemoteVersion prints a single version line with markers.
+func printRemoteVersion(ver, lts string, installed map[string]bool, activeVer, defaultVer string) {
+	isInstalled := installed[ver]
+	isActive := activeVer != "" && ver == activeVer
+	isDefault := defaultVer != "" && ver == defaultVer
+
+	activeMark := " "
+	if isActive {
+		activeMark = ">"
+	}
+	defaultMark := " "
+	if isDefault {
+		defaultMark = "*"
+	}
+	installedMark := " "
+	if isInstalled {
+		installedMark = "●"
+	}
+
+	suffix := ""
+	if lts != "" {
+		suffix = " (LTS: " + lts + ")"
+	}
+
+	line := activeMark + defaultMark + installedMark + " " + ver + suffix
+
+	switch {
+	case isActive && isDefault:
+		line = ioutil.Green(ioutil.Bold(line))
+	case isActive:
+		line = ioutil.Green(line)
+	case isInstalled:
+		// installed but not active: normal brightness
+	default:
+		line = ioutil.Dim(line)
+	}
+
+	fmt.Printf("  %s\n", line)
+}
+
+func printRemoteLegend(activeVer, defaultVer string) {
+	fmt.Println()
+	if activeVer != "" {
+		fmt.Println("  > = active (current directory)")
+	}
+	if defaultVer != "" {
+		fmt.Println("  * = global default")
+	}
+	fmt.Println("  ● = installed")
+}
+
+// ltsCodename extracts the LTS codename from the NodeRelease.LTS field.
+// Returns "" for non-LTS releases.
+func ltsCodename(lts any) string {
+	s, ok := lts.(string)
+	if !ok {
+		return ""
+	}
+	return s
 }

--- a/internal/installer/node.go
+++ b/internal/installer/node.go
@@ -153,7 +153,7 @@ func Install(versionStr string, verbose bool) (string, error) {
 // resolveLatestVersion finds the latest Node.js release matching a partial version.
 // The release index is sorted newest-first, so the first match is the latest.
 func resolveLatestVersion(v version.Version) (string, error) {
-	releases, err := fetchNodeIndex()
+	releases, err := FetchNodeIndex()
 	if err != nil {
 		return "", err
 	}
@@ -184,7 +184,9 @@ func ListInstalledToolVersions(tool string) ([]string, error) {
 	return platform.ListToolVersions(tool)
 }
 
-func fetchNodeIndex() ([]NodeRelease, error) {
+// FetchNodeIndex fetches the full Node.js release list from nodejs.org.
+// Releases are returned sorted newest-first. Version strings have the "v" prefix stripped.
+func FetchNodeIndex() ([]NodeRelease, error) {
 	resp, err := httpClient.Get(nodeIndexURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch Node.js release index: %w", err)
@@ -200,7 +202,6 @@ func fetchNodeIndex() ([]NodeRelease, error) {
 		return nil, fmt.Errorf("failed to parse release index: %w", err)
 	}
 
-	// Strip "v" prefix from versions.
 	for i := range releases {
 		releases[i].Version = strings.TrimPrefix(releases[i].Version, "v")
 	}

--- a/internal/installer/node_test.go
+++ b/internal/installer/node_test.go
@@ -1,0 +1,64 @@
+package installer
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFetchNodeIndex(t *testing.T) {
+	payload := []map[string]any{
+		{"version": "v24.1.0", "lts": false},
+		{"version": "v22.14.0", "lts": "Jod"},
+		{"version": "v20.19.2", "lts": "Iron"},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(payload)
+	}))
+	defer srv.Close()
+
+	orig := httpClient
+	httpClient = &http.Client{Transport: &hostRewriteTransport{target: srv.URL}}
+	defer func() { httpClient = orig }()
+
+	releases, err := FetchNodeIndex()
+	if err != nil {
+		t.Fatalf("FetchNodeIndex() error: %v", err)
+	}
+
+	if len(releases) != 3 {
+		t.Fatalf("expected 3 releases, got %d", len(releases))
+	}
+
+	// "v" prefix must be stripped.
+	if releases[0].Version != "24.1.0" {
+		t.Errorf("version[0] = %q, want 24.1.0", releases[0].Version)
+	}
+	if releases[1].Version != "22.14.0" {
+		t.Errorf("version[1] = %q, want 22.14.0", releases[1].Version)
+	}
+
+	// LTS field should round-trip as string for LTS releases.
+	lts, ok := releases[1].LTS.(string)
+	if !ok || lts != "Jod" {
+		t.Errorf("releases[1].LTS = %v, want \"Jod\"", releases[1].LTS)
+	}
+	if releases[0].LTS != false {
+		t.Errorf("releases[0].LTS = %v, want false", releases[0].LTS)
+	}
+}
+
+// hostRewriteTransport redirects all requests to a fixed base URL (test server).
+type hostRewriteTransport struct {
+	target string // e.g. "http://127.0.0.1:PORT"
+}
+
+func (t *hostRewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	cloned, err := http.NewRequest(req.Method, t.target+req.URL.Path, req.Body)
+	if err != nil {
+		return nil, err
+	}
+	cloned.Header = req.Header
+	return http.DefaultTransport.RoundTrip(cloned)
+}

--- a/internal/installer/registry.go
+++ b/internal/installer/registry.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/DriftrLabs/driftr/internal/ioutil"
@@ -116,6 +117,61 @@ func ResolveRegistryLatest(pkg string, v version.Version) (string, error) {
 		return "", fmt.Errorf("no %s version found matching %s", pkg, v.Raw)
 	}
 	return best.String(), nil
+}
+
+// ListRemoteVersions returns available versions of an npm package sorted newest-first.
+// Pre-release versions (those containing "-" in the version string) are excluded unless
+// includePre is true. Versions that cannot be parsed as semver are silently skipped.
+func ListRemoteVersions(pkg string, includePre bool) ([]string, error) {
+	url := fmt.Sprintf("%s/%s", registryBaseURL, pkg)
+	resp, err := httpClient.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch %s from registry: %w", pkg, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("npm registry returned status %d for %s", resp.StatusCode, pkg)
+	}
+
+	var rp registryPackage
+	if err := json.NewDecoder(resp.Body).Decode(&rp); err != nil {
+		return nil, fmt.Errorf("failed to parse registry response for %s: %w", pkg, err)
+	}
+
+	type entry struct {
+		ver version.Version
+		raw string
+	}
+	var entries []entry
+
+	for verStr := range rp.Versions {
+		isPre := strings.Contains(verStr, "-")
+		if !includePre && isPre {
+			continue
+		}
+		// Strip pre-release suffix before parsing so version.Parse succeeds
+		// (e.g. "9.2.0-rc.0" → parse "9.2.0" for sorting, keep original as raw).
+		parseStr := verStr
+		if isPre {
+			parseStr = verStr[:strings.Index(verStr, "-")]
+		}
+		v, err := version.Parse(parseStr)
+		if err != nil {
+			continue
+		}
+		entries = append(entries, entry{ver: v, raw: verStr})
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return versionCompare(entries[i].ver, entries[j].ver) > 0
+	})
+
+	result := make([]string, len(entries))
+	for i, e := range entries {
+		result[i] = e.raw
+	}
+	return result, nil
 }
 
 // versionCompare returns a positive value if a > b, negative if a < b, zero if equal.

--- a/internal/installer/registry_test.go
+++ b/internal/installer/registry_test.go
@@ -3,6 +3,9 @@ package installer
 import (
 	"crypto/sha512"
 	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -97,6 +100,64 @@ func TestVerifyIntegrity_UnsupportedAlgo(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected unsupported algorithm error, got nil")
 	}
+}
+
+func TestListRemoteVersions(t *testing.T) {
+	pkg := registryPackage{
+		Name:     "pnpm",
+		DistTags: map[string]string{"latest": "9.1.0"},
+		Versions: map[string]registryVersion{
+			"9.1.0":      {Version: "9.1.0"},
+			"9.0.0":      {Version: "9.0.0"},
+			"8.15.3":     {Version: "8.15.3"},
+			"9.2.0-rc.0": {Version: "9.2.0-rc.0"},
+			"bad-ver":    {Version: "bad-ver"},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(pkg)
+	}))
+	defer srv.Close()
+
+	orig := httpClient
+	httpClient = &http.Client{Transport: &hostRewriteTransport{target: srv.URL}}
+	defer func() { httpClient = orig }()
+
+	t.Run("stable only", func(t *testing.T) {
+		versions, err := ListRemoteVersions("pnpm", false)
+		if err != nil {
+			t.Fatalf("ListRemoteVersions() error: %v", err)
+		}
+		// Expect 3 stable versions, sorted descending, rc excluded.
+		if len(versions) != 3 {
+			t.Fatalf("expected 3 stable versions, got %d: %v", len(versions), versions)
+		}
+		if versions[0] != "9.1.0" {
+			t.Errorf("versions[0] = %q, want 9.1.0", versions[0])
+		}
+		if versions[1] != "9.0.0" {
+			t.Errorf("versions[1] = %q, want 9.0.0", versions[1])
+		}
+		if versions[2] != "8.15.3" {
+			t.Errorf("versions[2] = %q, want 8.15.3", versions[2])
+		}
+	})
+
+	t.Run("include pre-release", func(t *testing.T) {
+		versions, err := ListRemoteVersions("pnpm", true)
+		if err != nil {
+			t.Fatalf("ListRemoteVersions() error: %v", err)
+		}
+		// bad-ver cannot be parsed, so 4 valid versions (3 stable + 1 rc).
+		if len(versions) != 4 {
+			t.Fatalf("expected 4 versions, got %d: %v", len(versions), versions)
+		}
+		// rc should be first since 9.2.0 > 9.1.0.
+		if versions[0] != "9.2.0-rc.0" {
+			t.Errorf("versions[0] = %q, want 9.2.0-rc.0", versions[0])
+		}
+	})
 }
 
 func TestVersionCompare(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `driftr list --remote [tool]` to query nodejs.org / npm registry for available versions
- Installed (`●`), active (`>`), and global default (`*`) versions marked inline
- `--limit N` caps output (default 30); `--limit 0` shows all
- `--pre` includes pre-release versions (npm packages only)
- Node.js LTS releases show codename (e.g. `LTS: Jod`)
- Unsupported tools return a clear error listing valid options

## Test plan

- [x] `go test ./internal/installer/... ./internal/cli/...` passes
- [x] `driftr list --remote node --limit 10`
- [x] `driftr list --remote pnpm`
- [x] `driftr list --remote pnpm --pre`
- [x] `driftr list --remote yarn`
- [x] `driftr list --remote bogustool` returns error

Closes #41