### PR TITLE
fix: surface swallowed I/O errors in updater, installer, and config

### DIFF
--- a/internal/config/packagejson.go
+++ b/internal/config/packagejson.go
@@ -85,9 +85,12 @@ func SavePackageJSONTool(dir, tool, version string) error {
 		return fmt.Errorf("failed to read %s: %w", path, err)
 	}
 
-	// Load existing driftr config to preserve other tools.
+	// Load existing driftr config to preserve other tools. A parse failure
+	// must abort: writing with an empty config would drop other pinned tools.
 	var existing PackageJSON
-	_ = json.Unmarshal(data, &existing)
+	if err := json.Unmarshal(data, &existing); err != nil {
+		return fmt.Errorf("failed to parse %s: %w. Fix the file and retry", path, err)
+	}
 	existing.Driftr.SetTool(tool, version)
 
 	driftrValue, err := json.Marshal(existing.Driftr)

--- a/internal/config/packagejson_test.go
+++ b/internal/config/packagejson_test.go
@@ -391,3 +391,23 @@ func TestSavePackageJSON_PreservesIndentation(t *testing.T) {
 		t.Errorf("expected driftr key to use same 4-space indentation:\n%s", data)
 	}
 }
+
+func TestSavePackageJSONTool_MalformedDriftrKey(t *testing.T) {
+	dir := t.TempDir()
+	original := `{"name": "myapp", "driftr": {"node": 22, "pnpm": "9.15.0"}}`
+	writePackageJSON(t, dir, original)
+
+	err := SavePackageJSONTool(dir, "yarn", "4.5.0")
+	if err == nil {
+		t.Fatal("expected error for malformed driftr key, got nil")
+	}
+
+	// The file must be left untouched so no pinned tools are lost.
+	data, readErr := os.ReadFile(filepath.Join(dir, "package.json"))
+	if readErr != nil {
+		t.Fatalf("unexpected error: %v", readErr)
+	}
+	if string(data) != original {
+		t.Errorf("package.json was modified despite parse error:\ngot:  %s\nwant: %s", data, original)
+	}
+}

--- a/internal/installer/download.go
+++ b/internal/installer/download.go
@@ -1,6 +1,7 @@
 package installer
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -40,6 +41,16 @@ func DownloadURL(version string) string {
 func ArchiveFilename(version string) string {
 	return fmt.Sprintf("node-v%s-%s-%s.%s",
 		version, platform.OS(), platform.Arch(), platform.ArchiveExt())
+}
+
+// removeCorruptArchive deletes a cached archive that failed verification.
+// If removal fails, the corrupt archive would be reused on every subsequent
+// attempt, so the failure is surfaced with a manual remediation hint.
+func removeCorruptArchive(archivePath string, cause error) error {
+	if err := os.Remove(archivePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("%w (failed to remove corrupt archive; run 'rm %s' and retry)", cause, archivePath)
+	}
+	return cause
 }
 
 // Download fetches the Node.js archive to the cache directory.

--- a/internal/installer/download.go
+++ b/internal/installer/download.go
@@ -48,7 +48,7 @@ func ArchiveFilename(version string) string {
 // attempt, so the failure is surfaced with a manual remediation hint.
 func removeCorruptArchive(archivePath string, cause error) error {
 	if err := os.Remove(archivePath); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("%w (failed to remove corrupt archive; run 'rm %s' and retry)", cause, archivePath)
+		return fmt.Errorf("%w (failed to remove corrupt archive; run `rm %q` and retry)", cause, archivePath)
 	}
 	return cause
 }

--- a/internal/installer/download.go
+++ b/internal/installer/download.go
@@ -103,7 +103,11 @@ func Download(version string, verbose bool, cleanup *installCleanup) (string, er
 	} else {
 		_, err = io.Copy(tmpFile, limited)
 	}
-	tmpFile.Close()
+	// A failed close means a truncated file; it must not be renamed into the
+	// cache, where it would be treated as a valid archive.
+	if cerr := tmpFile.Close(); err == nil {
+		err = cerr
+	}
 	if err != nil {
 		os.Remove(tmpPath)
 		if cleanup != nil {

--- a/internal/installer/node.go
+++ b/internal/installer/node.go
@@ -134,7 +134,7 @@ func Install(versionStr string, verbose bool) (string, error) {
 
 	if err := VerifyChecksum(archivePath, resolvedVersion, verbose); err != nil {
 		// Remove corrupted cached archive so next attempt re-downloads.
-		os.Remove(archivePath)
+		err = removeCorruptArchive(archivePath, err)
 		cleanup.run()
 		return "", err
 	}

--- a/internal/installer/pnpm.go
+++ b/internal/installer/pnpm.go
@@ -53,15 +53,14 @@ func InstallPnpm(versionStr string, verbose bool) (string, error) {
 
 	// Verify integrity.
 	if rv.Dist.Integrity == "" {
-		os.Remove(archivePath)
-		return "", fmt.Errorf("registry metadata for pnpm %s is missing integrity data; refusing to install unverified package", resolvedVersion)
+		err := fmt.Errorf("registry metadata for pnpm %s is missing integrity data; refusing to install unverified package", resolvedVersion)
+		return "", removeCorruptArchive(archivePath, err)
 	}
 	if verbose {
 		fmt.Println("  Verifying integrity...")
 	}
 	if err := VerifyIntegrity(archivePath, rv.Dist.Integrity); err != nil {
-		os.Remove(archivePath)
-		return "", err
+		return "", removeCorruptArchive(archivePath, err)
 	}
 
 	// Extract to version directory.

--- a/internal/installer/registry.go
+++ b/internal/installer/registry.go
@@ -242,7 +242,11 @@ func DownloadRegistryPackage(pkg, ver string, verbose bool) (string, *registryVe
 	} else {
 		_, err = io.Copy(tmpFile, limited)
 	}
-	tmpFile.Close()
+	// A failed close means a truncated file; it must not be renamed into the
+	// cache, where it would be treated as a valid archive.
+	if cerr := tmpFile.Close(); err == nil {
+		err = cerr
+	}
 	if err != nil {
 		os.Remove(tmpPath)
 		return "", nil, fmt.Errorf("download interrupted: %w", err)

--- a/internal/installer/yarn.go
+++ b/internal/installer/yarn.go
@@ -52,15 +52,14 @@ func InstallYarn(versionStr string, verbose bool) (string, error) {
 
 	// Verify integrity.
 	if rv.Dist.Integrity == "" {
-		os.Remove(archivePath)
-		return "", fmt.Errorf("registry metadata for yarn %s is missing integrity data; refusing to install unverified package", resolvedVersion)
+		err := fmt.Errorf("registry metadata for yarn %s is missing integrity data; refusing to install unverified package", resolvedVersion)
+		return "", removeCorruptArchive(archivePath, err)
 	}
 	if verbose {
 		fmt.Println("  Verifying integrity...")
 	}
 	if err := VerifyIntegrity(archivePath, rv.Dist.Integrity); err != nil {
-		os.Remove(archivePath)
-		return "", err
+		return "", removeCorruptArchive(archivePath, err)
 	}
 
 	// Extract to version directory.

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -147,7 +147,6 @@ func downloadFile(url, dest string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
 
 	limited := io.LimitReader(resp.Body, maxUpdaterDownloadBytes)
 	if ioutil.IsTerminal(os.Stderr) {
@@ -156,6 +155,10 @@ func downloadFile(url, dest string) error {
 		pw.Finish()
 	} else {
 		_, err = io.Copy(f, limited)
+	}
+	// Close errors matter here: a failed flush means a truncated download.
+	if cerr := f.Close(); err == nil {
+		err = cerr
 	}
 	return err
 }
@@ -234,7 +237,10 @@ func extractBinary(archivePath, destPath string) error {
 				out.Close()
 				return err
 			}
-			out.Close()
+			// A failed close means a truncated binary on disk.
+			if err := out.Close(); err != nil {
+				return err
+			}
 			return nil
 		}
 	}


### PR DESCRIPTION
Fixes a family of swallowed-error bugs where I/O failures passed silently:

- **updater**: `Close()` errors on download and binary extraction were ignored — a failed flush (e.g. disk full) could leave a truncated binary that was treated as valid
- **installer**: `tmpFile.Close()` error ignored before renaming into the cache — a truncated archive could be cached as valid (node and registry download paths)
- **installer**: removal of a corrupt cached archive after checksum/integrity failure was unchecked — an undeletable archive would be reused and fail identically on every attempt; now fails with a manual cleanup hint via a shared `removeCorruptArchive` helper
- **config**: malformed `driftr` key in package.json aborted the parse silently, so saving a new tool version dropped every other pinned tool; now errors and leaves the file untouched (with regression test)

All unit tests pass.