### PR TITLE
fix: validate registry tarball URL before download

### DIFF
--- a/internal/installer/registry.go
+++ b/internal/installer/registry.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -185,6 +186,29 @@ func versionCompare(a, b version.Version) int {
 	return cmp.Compare(a.Patch, b.Patch)
 }
 
+// validateTarballURL ensures a registry-supplied tarball URL points back at
+// the npm registry over HTTPS. The URL comes from registry metadata, so a
+// poisoned response could otherwise send the download to an arbitrary host or
+// downgrade it to plaintext HTTP (CheckRedirect only guards redirects, not the
+// initial request).
+func validateTarballURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid tarball URL in registry metadata: %w", err)
+	}
+	registry, err := url.Parse(registryBaseURL)
+	if err != nil {
+		return fmt.Errorf("invalid registry base URL: %w", err)
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("refusing non-HTTPS tarball URL from registry metadata: %s", rawURL)
+	}
+	if u.Host != registry.Host {
+		return fmt.Errorf("refusing tarball URL from unexpected host %q (expected %q): %s", u.Host, registry.Host, rawURL)
+	}
+	return nil
+}
+
 // DownloadRegistryPackage downloads an npm package tarball to the cache directory.
 // Returns the path to the downloaded file and the registry version metadata.
 func DownloadRegistryPackage(pkg, ver string, verbose bool) (string, *registryVersion, error) {
@@ -214,6 +238,9 @@ func DownloadRegistryPackage(pkg, ver string, verbose bool) (string, *registryVe
 	}
 
 	tarballURL := rv.Dist.Tarball
+	if err := validateTarballURL(tarballURL); err != nil {
+		return "", nil, err
+	}
 	if verbose {
 		fmt.Printf("  Downloading: %s\n", tarballURL)
 	}

--- a/internal/installer/registry.go
+++ b/internal/installer/registry.go
@@ -201,10 +201,11 @@ func validateTarballURL(rawURL string) error {
 		return fmt.Errorf("invalid registry base URL: %w", err)
 	}
 	if u.Scheme != "https" {
-		return fmt.Errorf("refusing non-HTTPS tarball URL from registry metadata: %s", rawURL)
+		return fmt.Errorf("refusing non-HTTPS tarball URL from registry metadata: %q", rawURL)
 	}
-	if u.Host != registry.Host {
-		return fmt.Errorf("refusing tarball URL from unexpected host %q (expected %q): %s", u.Host, registry.Host, rawURL)
+	// DNS hostnames are case-insensitive.
+	if !strings.EqualFold(u.Host, registry.Host) {
+		return fmt.Errorf("refusing tarball URL from unexpected host %q (expected %q): %q", u.Host, registry.Host, rawURL)
 	}
 	return nil
 }

--- a/internal/installer/registry_test.go
+++ b/internal/installer/registry_test.go
@@ -188,3 +188,26 @@ func TestVersionCompare(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateTarballURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{"valid registry URL", "https://registry.npmjs.org/pnpm/-/pnpm-9.1.0.tgz", false},
+		{"plain HTTP rejected", "http://registry.npmjs.org/pnpm/-/pnpm-9.1.0.tgz", true},
+		{"wrong host rejected", "https://evil.example.com/pnpm-9.1.0.tgz", true},
+		{"host with port rejected", "https://registry.npmjs.org:8443/pnpm.tgz", true},
+		{"unparseable URL rejected", "https://registry.npmjs.org/%zz", true},
+		{"empty URL rejected", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateTarballURL(tt.url)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateTarballURL(%q) error = %v, wantErr %v", tt.url, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/installer/registry_test.go
+++ b/internal/installer/registry_test.go
@@ -196,6 +196,7 @@ func TestValidateTarballURL(t *testing.T) {
 		wantErr bool
 	}{
 		{"valid registry URL", "https://registry.npmjs.org/pnpm/-/pnpm-9.1.0.tgz", false},
+		{"mixed-case host accepted", "https://Registry.NPMJS.org/pnpm/-/pnpm-9.1.0.tgz", false},
 		{"plain HTTP rejected", "http://registry.npmjs.org/pnpm/-/pnpm-9.1.0.tgz", true},
 		{"wrong host rejected", "https://evil.example.com/pnpm-9.1.0.tgz", true},
 		{"host with port rejected", "https://registry.npmjs.org:8443/pnpm.tgz", true},


### PR DESCRIPTION
Hardens the npm registry download path:

- The tarball URL from registry metadata was fetched as-is. The HTTP client's `CheckRedirect` only guards redirects, not the initial request, so a poisoned metadata response could point the download at an arbitrary host or downgrade it to plaintext HTTP.
- `DownloadRegistryPackage` now rejects tarball URLs that are not HTTPS or do not match the registry host, with table-driven tests covering wrong host, HTTP downgrade, port variant, and malformed URLs.

Two other candidates from the security review were investigated and rejected as false positives: the updater's `extractBinary` never uses archive paths in filesystem operations (single output file at a fixed path), and `ExtractRegistryPackage` already sandboxes extraction with `os.Root`.