### PR TITLE
build(deps): bump cosign-installer to v4 and adapt signing to cosign v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           go-version-file: go.mod
           check-latest: true
           cache: true
-      - uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -56,19 +56,18 @@ checksum:
   name_template: checksums.txt
   algorithm: sha256
 
-# Keyless (Sigstore) signature of the checksums file. Verify with:
-#   cosign verify-blob --certificate checksums.txt.pem \
-#     --signature checksums.txt.sig \
+# Keyless (Sigstore) signature of the checksums file, in the cosign v3
+# bundle format. Verify with:
+#   cosign verify-blob --bundle checksums.txt.sigstore.json \
 #     --certificate-identity-regexp 'github.com/DriftrLabs/driftr' \
 #     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
 #     checksums.txt
 signs:
   - cmd: cosign
-    certificate: "${artifact}.pem"
+    signature: "${artifact}.sigstore.json"
     args:
       - sign-blob
-      - "--output-certificate=${certificate}"
-      - "--output-signature=${signature}"
+      - "--bundle=${signature}"
       - "${artifact}"
       - "--yes"
     artifacts: checksum


### PR DESCRIPTION
Supersedes #60. The plain action bump would break the next release: cosign v3 `sign-blob` requires bundle output.

- bump sigstore/cosign-installer to v4.1.2 (same SHA as #60)
- goreleaser signs step now emits `checksums.txt.sigstore.json` (bundle format) instead of `.sig` + `.pem`
- verification command updated in .goreleaser.yml comment