### PR TITLE
fix: resolve medium and low priority backlog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Run shellcheck
-        run: shellcheck install.sh test.sh test_path_e2e.sh scripts/*.sh
+        run: shellcheck install.sh test.sh test_path_e2e.sh scripts/*.sh test/*.sh
 
   install-sh-smoke:
     name: install.sh smoke test

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,6 +34,16 @@ jobs:
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
+          # Capture the commit range now — the tag is deleted before release creation.
+          {
+            echo "changes<<CHANGES_EOF"
+            if [ "$prev" != "none" ]; then
+              git log --oneline --no-decorate "$prev"..HEAD | head -30
+            else
+              git log --oneline --no-decorate -10
+            fi
+            echo "CHANGES_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Run tests
         if: steps.newcommits.outputs.skip != 'true'
@@ -64,6 +74,11 @@ jobs:
             --notes "Automated nightly build from \`$(git rev-parse --short HEAD)\` on main.
 
           **This is an unstable pre-release. Not recommended for production use.**
+
+          Changes since the previous nightly:
+          \`\`\`
+          ${{ steps.newcommits.outputs.changes }}
+          \`\`\`
 
           Install: download the archive for your platform, extract, and place \`driftr\` on your PATH." \
             --prerelease

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,7 +46,7 @@ brews:
 
       Add ~/.driftr/bin to the FRONT of your PATH (before Homebrew):
         echo 'export PATH="$HOME/.driftr/bin:$PATH"' >> ~/.zshenv
-        echo 'export PATH="$HOME/.driftr/bin:$PATH"' >> ~/.zprofile
+        echo 'export PATH="$HOME/.driftr/bin:$PATH"' >> ~/.zshrc
 
       Or run `driftr doctor --fix` to configure PATH automatically.
     test: |

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -5,6 +5,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN go build -o /usr/local/bin/driftr ./cmd/driftr/
+RUN go build -o /usr/local/bin/fixture-server ./test/fixture-server/
 
 FROM debian:bookworm-slim
 
@@ -13,14 +14,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /usr/local/bin/driftr /usr/local/bin/driftr
+COPY --from=builder /usr/local/bin/fixture-server /usr/local/bin/fixture-server
 
 # Create a non-root user for testing
 RUN useradd -m -s /bin/bash driftr
 USER driftr
 WORKDIR /home/driftr
 
-# Run the full test suite
+# Run the full test suite against the local fixture server (no real network)
 COPY --chown=driftr:driftr test.sh /home/driftr/test.sh
-RUN chmod +x /home/driftr/test.sh
+COPY --chown=driftr:driftr test/docker-entrypoint.sh /home/driftr/entrypoint.sh
+RUN chmod +x /home/driftr/test.sh /home/driftr/entrypoint.sh
 
-CMD ["/home/driftr/test.sh"]
+CMD ["/home/driftr/entrypoint.sh"]

--- a/cmd/driftr/main.go
+++ b/cmd/driftr/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -18,6 +19,10 @@ func main() {
 		if err != nil {
 			rb, err = cli.HandleShimError(err, tool)
 			if err != nil {
+				var exitErr *cli.ExitError
+				if errors.As(err, &exitErr) {
+					os.Exit(exitErr.Code)
+				}
 				fmt.Fprintf(os.Stderr, "driftr: %s\n", err)
 				os.Exit(1)
 			}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    patch:
+      default:
+        informational: true
+ignore:
+  - "test/**"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -129,6 +129,17 @@ git add .driftr.toml   # or package.json
 git commit -m "Pin Node.js version with Driftr"
 ```
 
+## Environment Variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `DRIFTR_NODE_MIRROR` | `https://nodejs.org/dist` | Alternative Node.js distribution mirror (corporate mirrors, air-gapped setups, hermetic tests). Must serve the same layout: `index.json`, `v<version>/SHASUMS256.txt`, and version tarballs. |
+| `DRIFTR_NPM_REGISTRY` | `https://registry.npmjs.org` | Alternative npm registry for pnpm/yarn installs. Tarball URLs in registry metadata must point back at the same host. |
+
+```bash
+DRIFTR_NODE_MIRROR=https://npmmirror.com/mirrors/node driftr install node@22
+```
+
 ## Storage Layout
 
 Driftr stores all data under `~/.driftr/`:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -193,8 +193,30 @@ Group tests under numbered section headers to keep them organized.
 ### Larger Features
 
 - Windows support (`.cmd` shims, `.zip` extraction)
-- Mirror configuration for custom download sources
 - yarn berry (3+/4+) support
+
+## Release Process (maintainers)
+
+Releases are fully automated — no version bump in source; build metadata is
+injected via ldflags.
+
+```bash
+git checkout main && git pull
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+The tag push triggers `.github/workflows/release.yml`, which:
+
+1. Runs the full test suite (a failing suite blocks the release)
+2. Runs GoReleaser: builds linux/darwin × amd64/arm64 archives, generates
+   `checksums.txt`, signs it with keyless cosign, publishes the GitHub
+   release, and updates the Homebrew tap formula
+3. Attests build provenance for all artifacts (verify with
+   `gh attestation verify`)
+
+Nightly pre-releases build automatically from main at 02:00 UTC when new
+commits exist.
 
 ## Reporting Bugs
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -58,13 +58,13 @@ driftr setup
 
 Driftr's shims (`node`, `npm`, `pnpm`, `yarn`) live in `~/.driftr/bin/`. For version pinning to work, this directory must appear **before** Homebrew paths in `PATH`.
 
-On macOS, `/usr/libexec/path_helper` runs at login shell startup and pushes `/opt/homebrew/bin` to the front, which causes Homebrew's system `node` (if installed) to shadow Driftr's shims. To fix this, add the PATH export to files sourced *after* `path_helper`:
+On macOS, `/usr/libexec/path_helper` runs at login shell startup (often together with `brew shellenv` in `~/.zprofile`) and pushes `/opt/homebrew/bin` to the front, which causes Homebrew's system `node` (if installed) to shadow Driftr's shims. To fix this, add the PATH export to a file sourced *after* `path_helper`:
 
-**Zsh** — add to both `~/.zshenv` and `~/.zprofile`:
+**Zsh** — add to both `~/.zshenv` (covers scripts, cron, IDE terminals) and `~/.zshrc` (sourced last in interactive sessions, so the shim dir wins over `path_helper`):
 
 ```bash
 echo 'export PATH="$HOME/.driftr/bin:$PATH"' >> ~/.zshenv
-echo 'export PATH="$HOME/.driftr/bin:$PATH"' >> ~/.zprofile
+echo 'export PATH="$HOME/.driftr/bin:$PATH"' >> ~/.zshrc
 ```
 
 **Bash** — add to `~/.bash_profile`:
@@ -151,14 +151,16 @@ echo 'export PATH="$HOME/.driftr/bin:$PATH"' >> ~/.zshenv
 ```
 
 `.zshenv` is sourced by every zsh invocation — interactive shells, scripts, cron, and IDE
-terminals. Do not use `.zshrc`, which is only sourced for interactive shells.
+terminals — and is the primary location. On its own it is not enough for interactive
+shells on macOS, though:
 
 > **macOS note:** Login shells invoke `/usr/libexec/path_helper`, which reorders PATH and pushes
 > Homebrew (`/opt/homebrew/bin`) to the front. To guarantee Driftr wins, also add the export to
-> `~/.zprofile` (runs after `path_helper`):
+> `~/.zshrc` (sourced last in interactive sessions). This matches what `install.sh` and
+> `driftr doctor --fix` configure automatically:
 >
 > ```bash
-> echo 'export PATH="$HOME/.driftr/bin:$PATH"' >> ~/.zprofile
+> echo 'export PATH="$HOME/.driftr/bin:$PATH"' >> ~/.zshrc
 > ```
 >
 > See the [Homebrew section](#homebrew-macos-and-linux) above for a detailed explanation.

--- a/install.sh
+++ b/install.sh
@@ -103,9 +103,16 @@ verify_checksum() {
     checksums_file="$2"
     filename="$(basename "$archive")"
 
-    expected=$(grep "$filename" "$checksums_file" | awk '{print $1}')
+    # Exact second-field match — a substring grep could match the wrong line.
+    expected=$(awk -v f="$filename" 'NF == 2 && $2 == f { print $1; exit }' "$checksums_file")
     if [ -z "$expected" ]; then
         err "no checksum found for $filename in checksums.txt"
+    fi
+    case "$expected" in
+        *[!0-9a-f]*) err "malformed checksum for $filename in checksums.txt" ;;
+    esac
+    if [ "${#expected}" -ne 64 ]; then
+        err "malformed checksum for $filename in checksums.txt"
     fi
 
     if command -v sha256sum >/dev/null 2>&1; then

--- a/internal/cli/cache.go
+++ b/internal/cli/cache.go
@@ -49,9 +49,11 @@ func newCacheCleanCmd() *cobra.Command {
 			}
 
 			var totalSize int64
+			unsized := 0
 			for _, entry := range entries {
 				info, err := entry.Info()
 				if err != nil {
+					unsized++
 					continue
 				}
 				totalSize += info.Size()
@@ -61,7 +63,11 @@ func newCacheCleanCmd() *cobra.Command {
 				return fmt.Errorf("failed to clean cache: %w", err)
 			}
 
-			fmt.Printf("Removed %d cached file(s), freed %s.\n", len(entries), formatSize(totalSize))
+			summary := fmt.Sprintf("Removed %d cached file(s), freed %s", len(entries), formatSize(totalSize))
+			if unsized > 0 {
+				summary += fmt.Sprintf(" (size of %d file(s) unknown)", unsized)
+			}
+			fmt.Println(summary + ".")
 			return nil
 		},
 	}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -162,7 +162,11 @@ func checkShimBinaryPath(binDir string) int {
 	if err != nil {
 		return 0
 	}
-	currentBin, _ = filepath.EvalSymlinks(currentBin)
+	// Keep the unresolved path on error — overwriting with "" would make the
+	// comparison below always mismatch and produce a false warning.
+	if resolved, err := filepath.EvalSymlinks(currentBin); err == nil {
+		currentBin = resolved
+	}
 
 	shimPath := filepath.Join(binDir, "node")
 	data, err := os.ReadFile(shimPath)
@@ -175,8 +179,8 @@ func checkShimBinaryPath(binDir string) int {
 		rest := content[idx+len(shimExecPrefix):]
 		if end := strings.Index(rest, "\""); end >= 0 {
 			shimBin := rest[:end]
-			resolved, _ := filepath.EvalSymlinks(shimBin)
-			if resolved == "" {
+			resolved, err := filepath.EvalSymlinks(shimBin)
+			if err != nil || resolved == "" {
 				resolved = shimBin
 			}
 			if resolved != currentBin {

--- a/internal/cli/pin.go
+++ b/internal/cli/pin.go
@@ -152,7 +152,9 @@ func migratePin(dir, tool, versionStr string, current pinFormat) error {
 		if err := config.SavePackageJSONTool(dir, tool, versionStr); err != nil {
 			return err
 		}
-		os.Remove(filepath.Join(dir, config.ProjectConfigFile))
+		if err := os.Remove(filepath.Join(dir, config.ProjectConfigFile)); err != nil {
+			return fmt.Errorf("migrated to package.json but failed to remove %s: %w. Remove it manually — it takes precedence over package.json", config.ProjectConfigFile, err)
+		}
 		fmt.Printf("Migrated %s %s from %s to package.json\n", tool, versionStr, config.ProjectConfigFile)
 
 	case formatPackageJSON:

--- a/internal/cli/shim_cmd.go
+++ b/internal/cli/shim_cmd.go
@@ -70,7 +70,9 @@ func HandleShimError(err error, tool string) (*resolver.ResolvedBinary, error) {
 	}
 
 	if !promptInstall(notInstalled) {
-		os.Exit(1)
+		// User declined — fail quietly with a non-zero code; the prompt
+		// already explained the situation.
+		return nil, &ExitError{Code: 1}
 	}
 
 	return autoInstall(notInstalled, tool)

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -73,7 +73,7 @@ func newUninstallCmd() *cobra.Command {
 			}
 
 			if err := os.RemoveAll(versionDir); err != nil {
-				return fmt.Errorf("failed to remove %s %s: %w", tool, versionStr, err)
+				return fmt.Errorf("failed to remove %s %s: %w. Manual cleanup: rm -rf %q", tool, versionStr, err, versionDir)
 			}
 
 			fmt.Printf("Uninstalled %s %s\n", tool, versionStr)

--- a/internal/installer/checksum.go
+++ b/internal/installer/checksum.go
@@ -14,7 +14,7 @@ import (
 
 // ShasumsURL returns the URL for the SHASUMS256.txt file for a given Node.js version.
 func ShasumsURL(version string) string {
-	return fmt.Sprintf("%s/v%s/SHASUMS256.txt", nodeDistBaseURL, version)
+	return fmt.Sprintf("%s/v%s/SHASUMS256.txt", nodeDistBase(), version)
 }
 
 // FetchExpectedChecksum downloads SHASUMS256.txt and extracts the hash for the given filename.

--- a/internal/installer/download.go
+++ b/internal/installer/download.go
@@ -7,13 +7,23 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/DriftrLabs/driftr/internal/ioutil"
 	"github.com/DriftrLabs/driftr/internal/platform"
 )
 
-const nodeDistBaseURL = "https://nodejs.org/dist"
+const defaultNodeDistBaseURL = "https://nodejs.org/dist"
+
+// nodeDistBase returns the Node.js distribution base URL. DRIFTR_NODE_MIRROR
+// overrides the default — for corporate mirrors and hermetic tests.
+func nodeDistBase() string {
+	if m := os.Getenv("DRIFTR_NODE_MIRROR"); m != "" {
+		return strings.TrimRight(m, "/")
+	}
+	return defaultNodeDistBaseURL
+}
 
 const maxNodeDownloadBytes = 500 * 1024 * 1024 // 500 MB
 
@@ -34,7 +44,7 @@ var httpClient = &http.Client{
 // DownloadURL returns the download URL for a given Node.js version.
 func DownloadURL(version string) string {
 	filename := ArchiveFilename(version)
-	return fmt.Sprintf("%s/v%s/%s", nodeDistBaseURL, version, filename)
+	return fmt.Sprintf("%s/v%s/%s", nodeDistBase(), version, filename)
 }
 
 // ArchiveFilename returns the expected archive filename.

--- a/internal/installer/download_test.go
+++ b/internal/installer/download_test.go
@@ -149,3 +149,13 @@ func TestDownload_EmptyCachedFileRedownloads(t *testing.T) {
 		t.Errorf("zero-byte cache entry was not re-downloaded: got %q", got)
 	}
 }
+
+func TestNodeDistBase_EnvOverride(t *testing.T) {
+	t.Setenv("DRIFTR_NODE_MIRROR", "http://127.0.0.1:9123/")
+	if got := nodeDistBase(); got != "http://127.0.0.1:9123" {
+		t.Errorf("nodeDistBase() = %q, want trailing slash trimmed", got)
+	}
+	if got := DownloadURL("22.0.0"); !strings.HasPrefix(got, "http://127.0.0.1:9123/v22.0.0/") {
+		t.Errorf("DownloadURL did not use mirror: %q", got)
+	}
+}

--- a/internal/installer/extract.go
+++ b/internal/installer/extract.go
@@ -123,6 +123,7 @@ func Extract(archivePath, version string, verbose bool) error {
 
 	// The archive contains "node-v<version>-<os>-<arch>/" as prefix.
 	prefix := fmt.Sprintf("node-v%s-%s-%s/", version, platform.OS(), platform.Arch())
+	matched := false
 
 	for {
 		hdr, err := tr.Next()
@@ -139,6 +140,7 @@ func Extract(archivePath, version string, verbose bool) error {
 		if !strings.HasPrefix(name, prefix) {
 			continue
 		}
+		matched = true
 
 		// Strip the archive prefix to get the relative path.
 		relPath := strings.TrimPrefix(name, prefix)
@@ -151,6 +153,14 @@ func Extract(archivePath, version string, verbose bool) error {
 			os.RemoveAll(tmpDir)
 			return err
 		}
+	}
+
+	// A valid Node.js archive always contains the version-prefixed directory.
+	// No matches means a wrong or corrupted archive, not a partial install.
+	if !matched {
+		root.Close()
+		os.RemoveAll(tmpDir)
+		return fmt.Errorf("archive has unexpected layout: no entries under %q. Run 'driftr cache clean' and retry", prefix)
 	}
 
 	// Verify the node binary exists after extraction.

--- a/internal/installer/extract.go
+++ b/internal/installer/extract.go
@@ -77,11 +77,18 @@ func Extract(archivePath, version string, verbose bool) error {
 		return nil
 	}
 
-	tmpDir := fmt.Sprintf("%s.tmp-%d", destDir, os.Getpid())
-	os.RemoveAll(tmpDir) // clear stale tmp from prior crash with same PID
-
-	if err := os.MkdirAll(tmpDir, 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(destDir), 0o755); err != nil {
+		return fmt.Errorf("failed to create tools dir: %w", err)
+	}
+	// MkdirTemp guarantees a unique name, so concurrent installs of the same
+	// version cannot clobber each other's work dir.
+	tmpDir, err := os.MkdirTemp(filepath.Dir(destDir), filepath.Base(destDir)+".tmp-")
+	if err != nil {
 		return fmt.Errorf("failed to create version dir: %w", err)
+	}
+	if err := os.Chmod(tmpDir, 0o755); err != nil {
+		os.RemoveAll(tmpDir)
+		return fmt.Errorf("failed to set version dir permissions: %w", err)
 	}
 
 	if verbose {

--- a/internal/installer/extract_test.go
+++ b/internal/installer/extract_test.go
@@ -290,3 +290,26 @@ func TestRemoveCorruptArchive_Undeletable(t *testing.T) {
 		t.Errorf("expected remediation hint in error, got: %v", err)
 	}
 }
+
+func TestExtract_WrongArchiveLayout(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	const ver = "99.0.0"
+
+	// No entry carries the expected node-v<ver>-<os>-<arch>/ prefix.
+	archive := buildTarGz(t, []tarEntry{
+		{Name: "something-else/bin/node", Data: []byte("node"), Typeflag: tar.TypeReg},
+	})
+
+	err := Extract(archive, ver, false)
+	if err == nil || !strings.Contains(err.Error(), "unexpected layout") {
+		t.Fatalf("expected unexpected-layout error, got: %v", err)
+	}
+
+	destDir, err := platform.NodeVersionDir(ver)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, statErr := os.Stat(destDir); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("version dir left behind after layout error: %s", destDir)
+	}
+}

--- a/internal/installer/node.go
+++ b/internal/installer/node.go
@@ -64,8 +64,6 @@ func (c *installCleanup) run() {
 	}
 }
 
-const nodeIndexURL = "https://nodejs.org/dist/index.json"
-
 // NodeRelease represents a single Node.js release from the index.
 type NodeRelease struct {
 	Version string `json:"version"`
@@ -187,7 +185,7 @@ func ListInstalledToolVersions(tool string) ([]string, error) {
 // FetchNodeIndex fetches the full Node.js release list from nodejs.org.
 // Releases are returned sorted newest-first. Version strings have the "v" prefix stripped.
 func FetchNodeIndex() ([]NodeRelease, error) {
-	resp, err := httpClient.Get(nodeIndexURL)
+	resp, err := httpClient.Get(nodeDistBase() + "/index.json")
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch Node.js release index: %w", err)
 	}

--- a/internal/installer/registry.go
+++ b/internal/installer/registry.go
@@ -20,7 +20,16 @@ import (
 	"github.com/DriftrLabs/driftr/internal/version"
 )
 
-const registryBaseURL = "https://registry.npmjs.org"
+const defaultRegistryBaseURL = "https://registry.npmjs.org"
+
+// registryBase returns the npm registry base URL. DRIFTR_NPM_REGISTRY
+// overrides the default — for corporate mirrors and hermetic tests.
+func registryBase() string {
+	if m := os.Getenv("DRIFTR_NPM_REGISTRY"); m != "" {
+		return strings.TrimRight(m, "/")
+	}
+	return defaultRegistryBaseURL
+}
 
 const maxRegistryDownloadBytes = 50 * 1024 * 1024 // 50 MB
 
@@ -48,7 +57,7 @@ type registryDist struct {
 
 // FetchRegistryVersion fetches metadata for a specific package version from the npm registry.
 func FetchRegistryVersion(pkg, ver string) (*registryVersion, error) {
-	url := fmt.Sprintf("%s/%s/%s", registryBaseURL, pkg, ver)
+	url := fmt.Sprintf("%s/%s/%s", registryBase(), pkg, ver)
 	resp, err := httpClient.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch %s@%s from registry: %w", pkg, ver, err)
@@ -72,7 +81,7 @@ func FetchRegistryVersion(pkg, ver string) (*registryVersion, error) {
 // ResolveRegistryLatest finds the latest version of an npm package matching a partial version spec.
 // For "latest" or when no constraint is given, returns the dist-tag "latest".
 func ResolveRegistryLatest(pkg string, v version.Version) (string, error) {
-	url := fmt.Sprintf("%s/%s", registryBaseURL, pkg)
+	url := fmt.Sprintf("%s/%s", registryBase(), pkg)
 	resp, err := httpClient.Get(url)
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch %s from registry: %w", pkg, err)
@@ -124,7 +133,7 @@ func ResolveRegistryLatest(pkg string, v version.Version) (string, error) {
 // Pre-release versions (those containing "-" in the version string) are excluded unless
 // includePre is true. Versions that cannot be parsed as semver are silently skipped.
 func ListRemoteVersions(pkg string, includePre bool) ([]string, error) {
-	url := fmt.Sprintf("%s/%s", registryBaseURL, pkg)
+	url := fmt.Sprintf("%s/%s", registryBase(), pkg)
 	resp, err := httpClient.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch %s from registry: %w", pkg, err)
@@ -187,21 +196,22 @@ func versionCompare(a, b version.Version) int {
 }
 
 // validateTarballURL ensures a registry-supplied tarball URL points back at
-// the npm registry over HTTPS. The URL comes from registry metadata, so a
+// the configured npm registry. The URL comes from registry metadata, so a
 // poisoned response could otherwise send the download to an arbitrary host or
 // downgrade it to plaintext HTTP (CheckRedirect only guards redirects, not the
-// initial request).
+// initial request). With the default registry this enforces HTTPS +
+// registry.npmjs.org; a DRIFTR_NPM_REGISTRY override must match itself exactly.
 func validateTarballURL(rawURL string) error {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return fmt.Errorf("invalid tarball URL in registry metadata: %w", err)
 	}
-	registry, err := url.Parse(registryBaseURL)
+	registry, err := url.Parse(registryBase())
 	if err != nil {
 		return fmt.Errorf("invalid registry base URL: %w", err)
 	}
-	if u.Scheme != "https" {
-		return fmt.Errorf("refusing non-HTTPS tarball URL from registry metadata: %q", rawURL)
+	if u.Scheme != registry.Scheme {
+		return fmt.Errorf("refusing tarball URL with scheme %q (registry uses %q): %q", u.Scheme, registry.Scheme, rawURL)
 	}
 	// DNS hostnames are case-insensitive.
 	if !strings.EqualFold(u.Host, registry.Host) {

--- a/internal/installer/registry_extract.go
+++ b/internal/installer/registry_extract.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -14,9 +15,6 @@ import (
 // npm tarballs contain a top-level "package/" prefix which is stripped during extraction.
 // binaryPath is used to detect a concurrent install race on rename failure.
 func ExtractRegistryPackage(archivePath, destDir, binaryPath string) error {
-	tmpDir := fmt.Sprintf("%s.tmp-%d", destDir, os.Getpid())
-	os.RemoveAll(tmpDir) // clear stale tmp from prior crash with same PID
-
 	f, err := os.Open(archivePath)
 	if err != nil {
 		return fmt.Errorf("failed to open archive: %w", err)
@@ -29,8 +27,18 @@ func ExtractRegistryPackage(archivePath, destDir, binaryPath string) error {
 	}
 	defer gz.Close()
 
-	if err := os.MkdirAll(tmpDir, 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(destDir), 0o755); err != nil {
+		return fmt.Errorf("failed to create tools dir: %w", err)
+	}
+	// MkdirTemp guarantees a unique name, so concurrent installs of the same
+	// version cannot clobber each other's work dir.
+	tmpDir, err := os.MkdirTemp(filepath.Dir(destDir), filepath.Base(destDir)+".tmp-")
+	if err != nil {
 		return fmt.Errorf("failed to create destination dir: %w", err)
+	}
+	if err := os.Chmod(tmpDir, 0o755); err != nil {
+		os.RemoveAll(tmpDir)
+		return fmt.Errorf("failed to set destination dir permissions: %w", err)
 	}
 
 	// Use os.Root to sandbox all file operations within tmpDir.

--- a/internal/installer/registry_test.go
+++ b/internal/installer/registry_test.go
@@ -212,3 +212,21 @@ func TestValidateTarballURL(t *testing.T) {
 		})
 	}
 }
+
+func TestRegistryBase_EnvOverride(t *testing.T) {
+	t.Setenv("DRIFTR_NPM_REGISTRY", "http://127.0.0.1:9123/")
+	if got := registryBase(); got != "http://127.0.0.1:9123" {
+		t.Errorf("registryBase() = %q, want trailing slash trimmed", got)
+	}
+}
+
+func TestValidateTarballURL_CustomRegistry(t *testing.T) {
+	t.Setenv("DRIFTR_NPM_REGISTRY", "http://127.0.0.1:9123")
+
+	if err := validateTarballURL("http://127.0.0.1:9123/pnpm/-/pnpm-9.1.0.tgz"); err != nil {
+		t.Errorf("tarball URL matching custom registry rejected: %v", err)
+	}
+	if err := validateTarballURL("https://registry.npmjs.org/pnpm/-/pnpm-9.1.0.tgz"); err == nil {
+		t.Error("tarball URL from a different host than the configured registry must be rejected")
+	}
+}

--- a/internal/ioutil/copy.go
+++ b/internal/ioutil/copy.go
@@ -21,7 +21,7 @@ func CopyFile(src, dst string) error {
 
 	if _, err := io.Copy(out, in); err != nil {
 		if cerr := out.Close(); cerr != nil {
-			return fmt.Errorf("copy failed: %w; close failed: %v", err, cerr)
+			return fmt.Errorf("copy failed: %w; close failed: %w", err, cerr)
 		}
 		return err
 	}

--- a/internal/ioutil/copy.go
+++ b/internal/ioutil/copy.go
@@ -17,8 +17,11 @@ func CopyFile(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer out.Close()
 
-	_, err = io.Copy(out, in)
-	return err
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	// A failed close means a truncated copy.
+	return out.Close()
 }

--- a/internal/ioutil/copy.go
+++ b/internal/ioutil/copy.go
@@ -1,6 +1,7 @@
 package ioutil
 
 import (
+	"fmt"
 	"io"
 	"os"
 )
@@ -19,7 +20,9 @@ func CopyFile(src, dst string) error {
 	}
 
 	if _, err := io.Copy(out, in); err != nil {
-		out.Close()
+		if cerr := out.Close(); cerr != nil {
+			return fmt.Errorf("copy failed: %w; close failed: %v", err, cerr)
+		}
 		return err
 	}
 	// A failed close means a truncated copy.

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 // DriftrHome returns the root directory for Driftr storage (~/.driftr).
@@ -194,7 +195,8 @@ func ListToolVersions(tool string) ([]string, error) {
 
 	var versions []string
 	for _, e := range entries {
-		if e.IsDir() {
+		// Skip in-progress or stale extraction work dirs (<version>.tmp-XXXX).
+		if e.IsDir() && !strings.Contains(e.Name(), ".tmp-") {
 			versions = append(versions, e.Name())
 		}
 	}

--- a/test/docker-entrypoint.sh
+++ b/test/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Entrypoint for the integration-test container: starts the local Node.js
+# distribution fixture so the test suite never touches the real network.
+set -eu
+
+fixture-server -addr 127.0.0.1:9123 &
+
+until curl -fsS http://127.0.0.1:9123/index.json > /dev/null 2>&1; do
+    sleep 0.1
+done
+
+export DRIFTR_NODE_MIRROR=http://127.0.0.1:9123
+exec /home/driftr/test.sh

--- a/test/fixture-server/main.go
+++ b/test/fixture-server/main.go
@@ -101,7 +101,7 @@ func main() {
 		fmt.Fprint(w, index)
 	})
 	mux.HandleFunc(fmt.Sprintf("/v%s/SHASUMS256.txt", fixtureVersion), func(w http.ResponseWriter, r *http.Request) {
-		w.Write(shasums.Bytes())
+		_, _ = w.Write(shasums.Bytes())
 	})
 	mux.HandleFunc(fmt.Sprintf("/v%s/", fixtureVersion), func(w http.ResponseWriter, r *http.Request) {
 		name := r.URL.Path[len(fmt.Sprintf("/v%s/", fixtureVersion)):]
@@ -111,7 +111,7 @@ func main() {
 			return
 		}
 		w.Header().Set("Content-Type", "application/gzip")
-		w.Write(data)
+		_, _ = w.Write(data)
 	})
 
 	log.Printf("fixture server listening on %s (node v%s)", *addr, fixtureVersion)

--- a/test/fixture-server/main.go
+++ b/test/fixture-server/main.go
@@ -1,0 +1,119 @@
+// Command fixture-server serves a minimal fake of nodejs.org/dist for
+// hermetic integration tests. Point driftr at it with
+// DRIFTR_NODE_MIRROR=http://127.0.0.1:<port>.
+//
+// It serves a single fake Node.js version for every os/arch combination:
+//
+//	/index.json                                  release index
+//	/v<ver>/SHASUMS256.txt                       checksums for all platforms
+//	/v<ver>/node-v<ver>-<os>-<arch>.tar.gz       fake tarball
+//
+// The tarballs contain shell scripts for bin/node, bin/npm, and bin/npx that
+// print plausible version strings, so shim-execution tests work without a
+// real Node.js download.
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"sort"
+)
+
+const fixtureVersion = "22.99.0"
+
+var platforms = []struct{ os, arch string }{
+	{"linux", "x64"},
+	{"linux", "arm64"},
+	{"darwin", "x64"},
+	{"darwin", "arm64"},
+}
+
+// buildTarball creates a fake Node.js release archive for one platform.
+func buildTarball(osName, arch string) ([]byte, error) {
+	prefix := fmt.Sprintf("node-v%s-%s-%s/", fixtureVersion, osName, arch)
+	scripts := map[string]string{
+		"bin/node": fmt.Sprintf("#!/bin/sh\necho \"v%s\"\n", fixtureVersion),
+		"bin/npm":  "#!/bin/sh\necho \"10.99.0\"\n",
+		"bin/npx":  "#!/bin/sh\necho \"10.99.0\"\n",
+	}
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	names := make([]string, 0, len(scripts))
+	for name := range scripts {
+		names = append(names, name)
+	}
+	sort.Strings(names) // deterministic archive bytes
+
+	for _, name := range names {
+		content := scripts[name]
+		hdr := &tar.Header{
+			Name:     prefix + name,
+			Mode:     0o755,
+			Size:     int64(len(content)),
+			Typeflag: tar.TypeReg,
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			return nil, err
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			return nil, err
+		}
+	}
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	if err := gz.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func main() {
+	addr := flag.String("addr", "127.0.0.1:9123", "listen address")
+	flag.Parse()
+
+	tarballs := map[string][]byte{} // filename -> archive bytes
+	var shasums bytes.Buffer
+	for _, p := range platforms {
+		data, err := buildTarball(p.os, p.arch)
+		if err != nil {
+			log.Fatalf("build tarball %s-%s: %v", p.os, p.arch, err)
+		}
+		filename := fmt.Sprintf("node-v%s-%s-%s.tar.gz", fixtureVersion, p.os, p.arch)
+		tarballs[filename] = data
+		fmt.Fprintf(&shasums, "%x  %s\n", sha256.Sum256(data), filename)
+	}
+
+	index := fmt.Sprintf(`[{"version":"v%s","lts":false}]`, fixtureVersion)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/index.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, index)
+	})
+	mux.HandleFunc(fmt.Sprintf("/v%s/SHASUMS256.txt", fixtureVersion), func(w http.ResponseWriter, r *http.Request) {
+		w.Write(shasums.Bytes())
+	})
+	mux.HandleFunc(fmt.Sprintf("/v%s/", fixtureVersion), func(w http.ResponseWriter, r *http.Request) {
+		name := r.URL.Path[len(fmt.Sprintf("/v%s/", fixtureVersion)):]
+		data, ok := tarballs[name]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/gzip")
+		w.Write(data)
+	})
+
+	log.Printf("fixture server listening on %s (node v%s)", *addr, fixtureVersion)
+	log.Fatal(http.ListenAndServe(*addr, mux))
+}


### PR DESCRIPTION
Closes out the remaining items from the improvement backlog.

**Correctness**
- Concurrent installs of the same version could clobber each other's temp dir; now uses `os.MkdirTemp`, and version listings filter `*.tmp-*` work dirs
- Wrong-layout archives now fail with a clear prefix-mismatch error instead of "node binary not found"
- `doctor` no longer emits a false shim warning when `EvalSymlinks` fails
- `pin --migrate` errors when the stale `.driftr.toml` can't be removed (it shadows package.json in resolution)
- `CopyFile` and uninstall/cache error paths no longer swallow failures
- install.sh: checksum matched on the exact filename field and validated as 64-hex
- `HandleShimError` returns `ExitError` instead of calling `os.Exit` directly

**Features**
- `DRIFTR_NODE_MIRROR` / `DRIFTR_NPM_REGISTRY` env overrides for custom mirrors (documented in docs/configuration.md)

**Tests/CI**
- Docker integration suite now runs against a local fixture server — passes under `--network none`
- Nightly release notes include the commit range since the previous nightly

**Docs**
- PATH guidance aligned with actual install.sh behavior (.zshenv + .zshrc)
- Release process documented for maintainers