### PR TITLE
build(deps): bump cosign-installer to v4 and adapt signing to cosign v3

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -56,19 +56,18 @@ checksum:
   name_template: checksums.txt
   algorithm: sha256
 
-# Keyless (Sigstore) signature of the checksums file. Verify with:
-#   cosign verify-blob --certificate checksums.txt.pem \
-#     --signature checksums.txt.sig \
+# Keyless (Sigstore) signature of the checksums file, in the cosign v3
+# bundle format. Verify with:
+#   cosign verify-blob --bundle checksums.txt.sigstore.json \
 #     --certificate-identity-regexp 'github.com/DriftrLabs/driftr' \
 #     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
 #     checksums.txt
 signs:
   - cmd: cosign
-    certificate: "${artifact}.pem"
+    signature: "${artifact}.sigstore.json"
     args:
       - sign-blob
-      - "--output-certificate=${certificate}"
-      - "--output-signature=${signature}"
+      - "--bundle=${signature}"
       - "${artifact}"
       - "--yes"
     artifacts: checksum


### PR DESCRIPTION
Replaces #64 (auto-closed when its branch was deleted) and supersedes #60.

The v0.9.0 release failed at the signing step — cosign-installer now resolves cosign 3.0.6, whose `sign-blob` requires bundle output (`create bundle file: open : no such file or directory` with the old flags).

- bump sigstore/cosign-installer to v4.1.2
- goreleaser signs step emits `checksums.txt.sigstore.json` (bundle format) instead of `.sig` + `.pem`
- verification command updated in .goreleaser.yml