### PR TITLE
feat: driftr node shared dependency storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,31 @@ pnpm -v   # resolves automatically
 | `driftr cache dir` | Print the cache directory path |
 | `driftr self-update` | Update Driftr to the latest version |
 | `driftr doctor [--fix]` | Check your Driftr installation for common problems |
+| `driftr node doctor` | Analyze the project's Node.js / pnpm dependency environment |
+| `driftr node optimize [--install]` | Configure pnpm for shared dependency storage (idempotent) |
+| `driftr node clean [--yes]` | Remove `node_modules` and prune the shared store (dry-run by default) |
+| `driftr node report` | Report `node_modules` size and shared pnpm store size |
 
 All commands support `-v` / `--verbose` for detailed output including resolver tracing and checksum details.
+
+### Shared dependency storage (`driftr node`)
+
+Driftr does not replace pnpm/npm/yarn. The `driftr node` commands configure and
+maintain pnpm's shared content-addressable store so dependencies are stored once
+and reused across every project on the machine, instead of duplicated in each
+`node_modules`.
+
+```bash
+driftr node doctor      # see current package manager + pnpm store configuration
+driftr node optimize    # enable corepack, point pnpm at ~/.driftr/stores/pnpm,
+                        # and turn on the global virtual store
+driftr node report      # compare project node_modules size vs shared store size
+driftr node clean       # dry-run: show what would be removed/pruned
+driftr node clean --yes # remove node_modules, reinstall, prune orphaned packages
+```
+
+`optimize` is idempotent — already-correct settings are left untouched — and
+requires pnpm (run `corepack enable` first if it is missing).
 
 ### Remote version listing flags
 

--- a/internal/cli/cache.go
+++ b/internal/cli/cache.go
@@ -91,10 +91,13 @@ func newCacheDirCmd() *cobra.Command {
 
 func formatSize(bytes int64) string {
 	const (
+		gb = 1024 * 1024 * 1024
 		mb = 1024 * 1024
 		kb = 1024
 	)
 	switch {
+	case bytes >= gb:
+		return fmt.Sprintf("%.1f GB", float64(bytes)/float64(gb))
 	case bytes >= mb:
 		return fmt.Sprintf("%.1f MB", float64(bytes)/float64(mb))
 	case bytes >= kb:

--- a/internal/cli/node_clean.go
+++ b/internal/cli/node_clean.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/DriftrLabs/driftr/internal/nodeenv"
+)
+
+func newNodeCleanCmd() *cobra.Command {
+	var yes bool
+	cmd := &cobra.Command{
+		Use:   "clean",
+		Short: "Remove node_modules and prune the shared store",
+		Long: "Reclaim disk space by removing the project's node_modules, reinstalling from\n" +
+			"the shared store, and pruning orphaned packages.\n\n" +
+			"Runs as a dry-run by default; pass --yes to perform the destructive operations.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dir, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			r := nodeenv.NewExecRunner()
+			return runNodeClean(nodeenv.NewPnpm(r), dir, yes, cmd.OutOrStdout())
+		},
+	}
+	cmd.Flags().BoolVar(&yes, "yes", false, "actually perform the cleanup (otherwise dry-run)")
+	return cmd
+}
+
+// runNodeClean removes node_modules, reinstalls, and prunes the store. With
+// doExecute=false it only reports what would happen and mutates nothing.
+func runNodeClean(p *nodeenv.Pnpm, projectDir string, doExecute bool, w io.Writer) error {
+	nodeModules := filepath.Join(projectDir, "node_modules")
+	size, _ := nodeenv.DirSize(nodeModules)
+	hasNodeModules := size > 0
+
+	if !doExecute {
+		fmt.Fprintln(w, "Dry run — no changes made. Re-run with --yes to execute.")
+		fmt.Fprintln(w)
+		if hasNodeModules {
+			fmt.Fprintf(w, "Would remove: %s (%s)\n", nodeModules, formatSize(size))
+			fmt.Fprintln(w, "Would run:    pnpm install")
+		} else {
+			fmt.Fprintln(w, "No node_modules to remove.")
+		}
+		fmt.Fprintln(w, "Would run:    pnpm store prune")
+		return nil
+	}
+
+	if hasNodeModules {
+		if err := os.RemoveAll(nodeModules); err != nil {
+			return fmt.Errorf("removing node_modules: %w", err)
+		}
+		fmt.Fprintf(w, "✓ removed node_modules (%s)\n", formatSize(size))
+	} else {
+		fmt.Fprintln(w, "• no node_modules to remove")
+	}
+
+	// Reinstall and prune require pnpm. If it is missing, the node_modules
+	// removal above still succeeded — warn rather than fail outright.
+	if !p.Installed() {
+		fmt.Fprintln(w, "⚠ pnpm not found — skipped reinstall and store prune.")
+		fmt.Fprintln(w, "  Run 'corepack enable', then 'pnpm install' to restore dependencies.")
+		return nil
+	}
+
+	if hasNodeModules {
+		fmt.Fprintln(w, "Running pnpm install...")
+		if _, err := p.Install(); err != nil {
+			return fmt.Errorf("pnpm install failed: %w", err)
+		}
+		fmt.Fprintln(w, "✓ dependencies reinstalled")
+	}
+
+	if _, err := p.StorePrune(); err != nil {
+		return fmt.Errorf("pnpm store prune failed: %w", err)
+	}
+	fmt.Fprintln(w, "✓ pruned orphaned packages from the shared store")
+	return nil
+}

--- a/internal/cli/node_clean.go
+++ b/internal/cli/node_clean.go
@@ -37,8 +37,13 @@ func newNodeCleanCmd() *cobra.Command {
 // doExecute=false it only reports what would happen and mutates nothing.
 func runNodeClean(p *nodeenv.Pnpm, projectDir string, doExecute bool, w io.Writer) error {
 	nodeModules := filepath.Join(projectDir, "node_modules")
+	// Presence is decided by stat, not size: an empty node_modules (or one
+	// holding only symlinks) still needs removing and reinstalling.
+	hasNodeModules := false
+	if info, err := os.Stat(nodeModules); err == nil && info.IsDir() {
+		hasNodeModules = true
+	}
 	size, _ := nodeenv.DirSize(nodeModules)
-	hasNodeModules := size > 0
 
 	if !doExecute {
 		fmt.Fprintln(w, "Dry run — no changes made. Re-run with --yes to execute.")

--- a/internal/cli/node_cmd.go
+++ b/internal/cli/node_cmd.go
@@ -1,0 +1,28 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// newNodeCmd is the parent for Node.js dependency-storage optimization
+// commands. It is distinct from the top-level `driftr doctor`, which checks the
+// driftr installation itself; `driftr node doctor` inspects the project's
+// Node.js / pnpm dependency environment.
+func newNodeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "node",
+		Short: "Optimize shared Node.js dependency storage",
+		Long: "Analyze and optimize how Node.js dependencies are stored across projects.\n\n" +
+			"Driftr does not replace pnpm/npm/yarn — it configures and maintains pnpm's\n" +
+			"shared content-addressable store to reduce duplicated dependency data.",
+	}
+
+	cmd.AddCommand(
+		newNodeDoctorCmd(),
+		newNodeOptimizeCmd(),
+		newNodeCleanCmd(),
+		newNodeReportCmd(),
+	)
+
+	return cmd
+}

--- a/internal/cli/node_doctor.go
+++ b/internal/cli/node_doctor.go
@@ -1,0 +1,146 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/DriftrLabs/driftr/internal/nodeenv"
+)
+
+// nodeDoctorInfo is the gathered state rendered by `driftr node doctor`.
+type nodeDoctorInfo struct {
+	projectDir         string
+	packageManager     nodeenv.PackageManager
+	nodeVersion        string // "" when node not found
+	corepackAvailable  bool
+	pnpmInstalled      bool
+	pnpmVersion        string
+	nodeModulesSize    int64
+	storePath          string // "" when pnpm missing/unknown
+	globalVirtualStore bool
+}
+
+func newNodeDoctorCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "doctor",
+		Short: "Analyze the Node.js dependency environment",
+		Long:  "Inspect the current project's package manager and pnpm shared-store configuration, and recommend optimizations.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dir, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			r := nodeenv.NewExecRunner()
+			info := gatherNodeDoctor(r, dir)
+			renderNodeDoctor(cmd.OutOrStdout(), info)
+			return nil
+		},
+	}
+}
+
+// gatherNodeDoctor collects environment state. It never fails on missing
+// tooling — absence is reported, not treated as an error.
+func gatherNodeDoctor(r nodeenv.Runner, projectDir string) nodeDoctorInfo {
+	p := nodeenv.NewPnpm(r)
+	info := nodeDoctorInfo{
+		projectDir:        projectDir,
+		packageManager:    nodeenv.DetectPackageManager(projectDir),
+		corepackAvailable: p.CorepackAvailable(),
+		pnpmInstalled:     p.Installed(),
+	}
+
+	if v, err := r.Run("node", "--version"); err == nil {
+		info.nodeVersion = strings.TrimPrefix(v, "v")
+	}
+
+	if size, err := nodeenv.DirSize(filepath.Join(projectDir, "node_modules")); err == nil {
+		info.nodeModulesSize = size
+	}
+
+	if info.pnpmInstalled {
+		if v, err := p.Version(); err == nil {
+			info.pnpmVersion = v
+		}
+		if path, err := p.StorePath(); err == nil {
+			info.storePath = path
+		}
+		if val, err := p.ConfigGet(nodeenv.GlobalVirtualStoreKey); err == nil {
+			info.globalVirtualStore = val == "true"
+		}
+	}
+
+	return info
+}
+
+func renderNodeDoctor(w io.Writer, info nodeDoctorInfo) {
+	fmt.Fprintln(w, "Driftr Node Doctor")
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "Project:         %s\n", info.projectDir)
+	fmt.Fprintf(w, "Package manager: %s\n", info.packageManager)
+	fmt.Fprintf(w, "Node.js:         %s\n", orNotFound(info.nodeVersion))
+	fmt.Fprintf(w, "Corepack:        %s\n", availability(info.corepackAvailable))
+
+	if info.pnpmInstalled {
+		fmt.Fprintf(w, "pnpm:            %s\n", orNotFound(info.pnpmVersion))
+	} else {
+		fmt.Fprintf(w, "pnpm:            not found\n")
+	}
+
+	if info.nodeModulesSize > 0 {
+		fmt.Fprintf(w, "node_modules:    %s\n", formatSize(info.nodeModulesSize))
+	} else {
+		fmt.Fprintf(w, "node_modules:    none\n")
+	}
+
+	fmt.Fprintf(w, "pnpm store:      %s\n", orUnknown(info.storePath))
+	fmt.Fprintf(w, "global virtual store: %s\n", enabledDisabled(info.globalVirtualStore))
+
+	if !info.pnpmInstalled {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Recommendation:")
+		fmt.Fprintln(w, "pnpm is not installed. Enable corepack to get it, then optimize storage.")
+		fmt.Fprintln(w, "Run: corepack enable && driftr node optimize")
+		return
+	}
+
+	if !info.globalVirtualStore {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Recommendation:")
+		fmt.Fprintln(w, "Enable pnpm shared storage to reduce duplicated dependency data.")
+		fmt.Fprintln(w, "Run: driftr node optimize")
+	}
+}
+
+func orNotFound(s string) string {
+	if s == "" {
+		return "not found"
+	}
+	return s
+}
+
+func orUnknown(s string) string {
+	if s == "" {
+		return "unknown"
+	}
+	return s
+}
+
+func availability(ok bool) string {
+	if ok {
+		return "available"
+	}
+	return "not found"
+}
+
+func enabledDisabled(on bool) string {
+	if on {
+		return "enabled"
+	}
+	return "disabled"
+}

--- a/internal/cli/node_optimize.go
+++ b/internal/cli/node_optimize.go
@@ -35,20 +35,22 @@ func newNodeOptimizeCmd() *cobra.Command {
 // runNodeOptimize applies the shared-store configuration idempotently. Returns
 // an actionable error when pnpm is unavailable.
 func runNodeOptimize(p *nodeenv.Pnpm, storeDir string, install bool, w io.Writer) error {
-	if !p.Installed() {
-		return fmt.Errorf("pnpm not found. Run 'corepack enable' to install it, then re-run 'driftr node optimize'")
-	}
-
 	fmt.Fprintln(w, "Optimizing pnpm shared dependency storage...")
 	fmt.Fprintln(w)
 
+	// corepack runs first: enabling it can make pnpm resolvable, so the pnpm
+	// availability check below must come after.
 	if p.CorepackAvailable() {
 		if err := p.CorepackEnable(); err != nil {
 			return fmt.Errorf("corepack enable failed: %w", err)
 		}
 		fmt.Fprintln(w, "✓ corepack enabled")
 	} else {
-		fmt.Fprintln(w, "• corepack not found, skipping (pnpm already available)")
+		fmt.Fprintln(w, "• corepack not found, skipping")
+	}
+
+	if !p.Installed() {
+		return fmt.Errorf("pnpm not found. Install pnpm (e.g. via 'corepack enable'), then re-run 'driftr node optimize'")
 	}
 
 	targets := []struct{ key, value string }{

--- a/internal/cli/node_optimize.go
+++ b/internal/cli/node_optimize.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/DriftrLabs/driftr/internal/nodeenv"
+	"github.com/DriftrLabs/driftr/internal/platform"
+)
+
+func newNodeOptimizeCmd() *cobra.Command {
+	var install bool
+	cmd := &cobra.Command{
+		Use:   "optimize",
+		Short: "Configure pnpm for shared dependency storage",
+		Long: "Enable corepack and point pnpm at driftr's shared content-addressable store,\n" +
+			"enabling the global virtual store so dependencies are shared across projects.\n" +
+			"Idempotent: already-correct settings are left untouched.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			storeDir, err := platform.PnpmStoreDir()
+			if err != nil {
+				return err
+			}
+			r := nodeenv.NewExecRunner()
+			return runNodeOptimize(nodeenv.NewPnpm(r), storeDir, install, cmd.OutOrStdout())
+		},
+	}
+	cmd.Flags().BoolVar(&install, "install", false, "run 'pnpm install' after configuring")
+	return cmd
+}
+
+// runNodeOptimize applies the shared-store configuration idempotently. Returns
+// an actionable error when pnpm is unavailable.
+func runNodeOptimize(p *nodeenv.Pnpm, storeDir string, install bool, w io.Writer) error {
+	if !p.Installed() {
+		return fmt.Errorf("pnpm not found. Run 'corepack enable' to install it, then re-run 'driftr node optimize'")
+	}
+
+	fmt.Fprintln(w, "Optimizing pnpm shared dependency storage...")
+	fmt.Fprintln(w)
+
+	if p.CorepackAvailable() {
+		if err := p.CorepackEnable(); err != nil {
+			return fmt.Errorf("corepack enable failed: %w", err)
+		}
+		fmt.Fprintln(w, "✓ corepack enabled")
+	} else {
+		fmt.Fprintln(w, "• corepack not found, skipping (pnpm already available)")
+	}
+
+	targets := []struct{ key, value string }{
+		{nodeenv.StoreDirKey, storeDir},
+		{nodeenv.GlobalVirtualStoreKey, "true"},
+	}
+	for _, t := range targets {
+		current, err := p.ConfigGet(t.key)
+		if err != nil {
+			return fmt.Errorf("reading pnpm config %q: %w", t.key, err)
+		}
+		if current == t.value {
+			fmt.Fprintf(w, "• %s already %s\n", t.key, t.value)
+			continue
+		}
+		if err := p.ConfigSet(t.key, t.value); err != nil {
+			return fmt.Errorf("setting pnpm config %q: %w", t.key, err)
+		}
+		fmt.Fprintf(w, "✓ set %s = %s\n", t.key, t.value)
+	}
+
+	if install {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Running pnpm install...")
+		if _, err := p.Install(); err != nil {
+			return fmt.Errorf("pnpm install failed: %w", err)
+		}
+		fmt.Fprintln(w, "✓ dependencies installed")
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Done. Dependencies are now stored in the shared pnpm store.")
+	return nil
+}

--- a/internal/cli/node_report.go
+++ b/internal/cli/node_report.go
@@ -37,12 +37,19 @@ func runNodeReport(p *nodeenv.Pnpm, projectDir string, w io.Writer) error {
 
 	var storeSize int64
 	storeKnown := false
-	if p.Installed() {
-		if path, err := p.StorePath(); err == nil && path != "" {
-			if s, err := nodeenv.DirSize(path); err == nil {
-				storeSize = s
-				storeKnown = true
-			}
+	storeNote := "unknown"
+	switch {
+	case !p.Installed():
+		storeNote = "unknown (pnpm not found)"
+	default:
+		path, err := p.StorePath()
+		if err != nil || path == "" {
+			storeNote = "unknown (could not determine store path)"
+		} else if s, err := nodeenv.DirSize(path); err != nil {
+			storeNote = "unknown (could not measure store)"
+		} else {
+			storeSize = s
+			storeKnown = true
 		}
 	}
 
@@ -53,7 +60,7 @@ func runNodeReport(p *nodeenv.Pnpm, projectDir string, w io.Writer) error {
 	if storeKnown {
 		fmt.Fprintf(w, "Shared pnpm store:     %s\n", formatSize(storeSize))
 	} else {
-		fmt.Fprintln(w, "Shared pnpm store:     unknown (pnpm not found)")
+		fmt.Fprintf(w, "Shared pnpm store:     %s\n", storeNote)
 	}
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "The shared pnpm store is reused across every project on this machine,")

--- a/internal/cli/node_report.go
+++ b/internal/cli/node_report.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/DriftrLabs/driftr/internal/nodeenv"
+)
+
+func newNodeReportCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "report",
+		Short: "Report dependency storage usage",
+		Long:  "Show the current project's node_modules size alongside the shared pnpm store size.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dir, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			r := nodeenv.NewExecRunner()
+			return runNodeReport(nodeenv.NewPnpm(r), dir, cmd.OutOrStdout())
+		},
+	}
+}
+
+// runNodeReport prints node_modules and shared-store sizes for the current
+// project. Scope is intentionally single-project: a cross-project "savings"
+// figure would be fabricated here, so the report states real sizes plus a note
+// that the store is shared machine-wide.
+func runNodeReport(p *nodeenv.Pnpm, projectDir string, w io.Writer) error {
+	nodeModulesSize, _ := nodeenv.DirSize(filepath.Join(projectDir, "node_modules"))
+
+	var storeSize int64
+	storeKnown := false
+	if p.Installed() {
+		if path, err := p.StorePath(); err == nil && path != "" {
+			if s, err := nodeenv.DirSize(path); err == nil {
+				storeSize = s
+				storeKnown = true
+			}
+		}
+	}
+
+	fmt.Fprintln(w, "Driftr Storage Report")
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "Project:               %s\n", projectDir)
+	fmt.Fprintf(w, "Project node_modules:  %s\n", formatSize(nodeModulesSize))
+	if storeKnown {
+		fmt.Fprintf(w, "Shared pnpm store:     %s\n", formatSize(storeSize))
+	} else {
+		fmt.Fprintln(w, "Shared pnpm store:     unknown (pnpm not found)")
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "The shared pnpm store is reused across every project on this machine,")
+	fmt.Fprintln(w, "so its cost is amortized — more projects means greater savings overall.")
+	return nil
+}

--- a/internal/cli/node_test.go
+++ b/internal/cli/node_test.go
@@ -138,6 +138,54 @@ func TestRunNodeClean_ExecuteRemovesAndPrunes(t *testing.T) {
 	}
 }
 
+func TestRunNodeClean_ExecuteRemovesEmptyNodeModules(t *testing.T) {
+	// Empty node_modules must still be removed and trigger reinstall — the old
+	// size>0 check wrongly treated it as absent.
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "node_modules"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	s := newStubRunner()
+	if err := runNodeClean(nodeenv.NewPnpm(s), dir, true, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "node_modules")); !os.IsNotExist(err) {
+		t.Errorf("empty node_modules should be removed, stat err=%v", err)
+	}
+	if !s.called("pnpm install") {
+		t.Errorf("expected reinstall after removing empty node_modules, got %v", s.calls)
+	}
+}
+
+func TestRunNodeOptimize_RunsCorepackBeforeFailing(t *testing.T) {
+	s := newStubRunner()
+	s.missing["pnpm"] = true // pnpm absent, corepack present
+	err := runNodeOptimize(nodeenv.NewPnpm(s), "/store/pnpm", false, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected error when pnpm still missing after corepack enable")
+	}
+	if !s.called("corepack enable") {
+		t.Errorf("corepack enable must be attempted before failing, got %v", s.calls)
+	}
+}
+
+func TestRunNodeReport_StorePathFailureNotReportedAsMissing(t *testing.T) {
+	dir := t.TempDir()
+	s := newStubRunner() // pnpm present, but "pnpm store path" returns empty
+	var buf bytes.Buffer
+	if err := runNodeReport(nodeenv.NewPnpm(s), dir, &buf); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if strings.Contains(out, "pnpm not found") {
+		t.Errorf("pnpm is present; must not claim 'pnpm not found': %s", out)
+	}
+	if !strings.Contains(out, "store path") {
+		t.Errorf("expected store-path failure note, got: %s", out)
+	}
+}
+
 func TestGatherNodeDoctor_RecommendsOptimizeWhenDisabled(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "pnpm-lock.yaml"), []byte(""), 0o644); err != nil {

--- a/internal/cli/node_test.go
+++ b/internal/cli/node_test.go
@@ -1,0 +1,203 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/DriftrLabs/driftr/internal/nodeenv"
+)
+
+// stubRunner implements nodeenv.Runner for command-level tests.
+type stubRunner struct {
+	calls   []string
+	outputs map[string]string
+	missing map[string]bool
+}
+
+func newStubRunner() *stubRunner {
+	return &stubRunner{outputs: map[string]string{}, missing: map[string]bool{}}
+}
+
+func (s *stubRunner) Run(name string, args ...string) (string, error) {
+	key := strings.TrimSpace(name + " " + strings.Join(args, " "))
+	s.calls = append(s.calls, key)
+	return s.outputs[key], nil
+}
+
+func (s *stubRunner) LookPath(name string) (string, error) {
+	if s.missing[name] {
+		return "", errors.New("not found")
+	}
+	return "/usr/bin/" + name, nil
+}
+
+func (s *stubRunner) called(cmd string) bool {
+	for _, c := range s.calls {
+		if c == cmd {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRunNodeOptimize_SetsUnconfiguredKeys(t *testing.T) {
+	s := newStubRunner()
+	// both keys read back empty → both should be set
+	var buf bytes.Buffer
+	if err := runNodeOptimize(nodeenv.NewPnpm(s), "/store/pnpm", false, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if !s.called("pnpm config set store-dir /store/pnpm") {
+		t.Errorf("expected store-dir to be set; calls=%v", s.calls)
+	}
+	if !s.called("pnpm config set enable-global-virtual-store true") {
+		t.Errorf("expected virtual-store to be set; calls=%v", s.calls)
+	}
+}
+
+func TestRunNodeOptimize_Idempotent(t *testing.T) {
+	s := newStubRunner()
+	s.outputs["pnpm config get store-dir"] = "/store/pnpm"
+	s.outputs["pnpm config get enable-global-virtual-store"] = "true"
+
+	var buf bytes.Buffer
+	if err := runNodeOptimize(nodeenv.NewPnpm(s), "/store/pnpm", false, &buf); err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range s.calls {
+		if strings.HasPrefix(c, "pnpm config set") {
+			t.Errorf("expected no config set when already configured, got %q", c)
+		}
+	}
+	if !strings.Contains(buf.String(), "already") {
+		t.Errorf("expected 'already' in output, got: %s", buf.String())
+	}
+}
+
+func TestRunNodeOptimize_PnpmMissing(t *testing.T) {
+	s := newStubRunner()
+	s.missing["pnpm"] = true
+	err := runNodeOptimize(nodeenv.NewPnpm(s), "/store/pnpm", false, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "corepack enable") {
+		t.Errorf("expected actionable pnpm-missing error, got: %v", err)
+	}
+}
+
+func TestRunNodeClean_DryRunMutatesNothing(t *testing.T) {
+	dir := t.TempDir()
+	nm := filepath.Join(dir, "node_modules", "pkg")
+	if err := os.MkdirAll(nm, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nm, "f"), make([]byte, 10), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := newStubRunner()
+	var buf bytes.Buffer
+	if err := runNodeClean(nodeenv.NewPnpm(s), dir, false, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "node_modules")); err != nil {
+		t.Errorf("dry-run must not remove node_modules: %v", err)
+	}
+	if len(s.calls) != 0 {
+		t.Errorf("dry-run must not run any command, got %v", s.calls)
+	}
+	if !strings.Contains(buf.String(), "Dry run") {
+		t.Errorf("expected dry-run notice, got: %s", buf.String())
+	}
+}
+
+func TestRunNodeClean_ExecuteRemovesAndPrunes(t *testing.T) {
+	dir := t.TempDir()
+	nm := filepath.Join(dir, "node_modules", "pkg")
+	if err := os.MkdirAll(nm, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nm, "f"), make([]byte, 10), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := newStubRunner()
+	if err := runNodeClean(nodeenv.NewPnpm(s), dir, true, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "node_modules")); !os.IsNotExist(err) {
+		t.Errorf("node_modules should be removed, stat err=%v", err)
+	}
+	if !s.called("pnpm install") {
+		t.Errorf("expected pnpm install, got %v", s.calls)
+	}
+	if !s.called("pnpm store prune") {
+		t.Errorf("expected pnpm store prune, got %v", s.calls)
+	}
+}
+
+func TestGatherNodeDoctor_RecommendsOptimizeWhenDisabled(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "pnpm-lock.yaml"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s := newStubRunner()
+	s.outputs["node --version"] = "v22.14.0"
+	s.outputs["pnpm --version"] = "9.1.0"
+	s.outputs["pnpm store path"] = "/store/pnpm"
+	s.outputs["pnpm config get enable-global-virtual-store"] = "undefined"
+
+	info := gatherNodeDoctor(s, dir)
+	if info.packageManager != nodeenv.PnpmManager {
+		t.Errorf("packageManager = %q, want pnpm", info.packageManager)
+	}
+	if info.nodeVersion != "22.14.0" {
+		t.Errorf("nodeVersion = %q, want 22.14.0", info.nodeVersion)
+	}
+	if info.globalVirtualStore {
+		t.Error("globalVirtualStore should be false for 'undefined'")
+	}
+
+	var buf bytes.Buffer
+	renderNodeDoctor(&buf, info)
+	if !strings.Contains(buf.String(), "driftr node optimize") {
+		t.Errorf("expected optimize recommendation, got: %s", buf.String())
+	}
+}
+
+func TestRunNodeReport_ShowsSizes(t *testing.T) {
+	dir := t.TempDir()
+	store := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "node_modules.placeholder"), make([]byte, 5), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "node_modules"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "node_modules", "x"), make([]byte, 2048), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(store, "blob"), make([]byte, 4096), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := newStubRunner()
+	s.outputs["pnpm store path"] = store
+
+	var buf bytes.Buffer
+	if err := runNodeReport(nodeenv.NewPnpm(s), dir, &buf); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Project node_modules:") || !strings.Contains(out, "Shared pnpm store:") {
+		t.Errorf("report missing size lines: %s", out)
+	}
+}
+
+func TestNodeCmd_HelpRegistered(t *testing.T) {
+	if err := runCmd(t, "node", "--help"); err != nil {
+		t.Errorf("node --help failed: %v", err)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -52,6 +52,7 @@ func NewRootCmd() *cobra.Command {
 		newCacheCmd(),
 		newDoctorCmd(),
 		newUpdateCmd(),
+		newNodeCmd(),
 	)
 
 	return root

--- a/internal/nodeenv/diskusage.go
+++ b/internal/nodeenv/diskusage.go
@@ -1,0 +1,38 @@
+package nodeenv
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// DirSize returns the total size in bytes of all regular files under path,
+// walking recursively. A non-existent path returns (0, nil) — callers treat a
+// missing node_modules or store as "empty", not an error.
+//
+// Symlinks are not followed (filepath.WalkDir uses Lstat), so linked store
+// content is not double-counted.
+func DirSize(path string) (int64, error) {
+	var total int64
+	err := filepath.WalkDir(path, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.Type().IsRegular() {
+			info, infoErr := d.Info()
+			if infoErr != nil {
+				return infoErr
+			}
+			total += info.Size()
+		}
+		return nil
+	})
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	return total, nil
+}

--- a/internal/nodeenv/diskusage_test.go
+++ b/internal/nodeenv/diskusage_test.go
@@ -1,0 +1,52 @@
+package nodeenv
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDirSize_SumsRegularFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a.txt"), 100)
+	writeFile(t, filepath.Join(dir, "sub", "b.txt"), 250)
+	writeFile(t, filepath.Join(dir, "sub", "deep", "c.txt"), 50)
+
+	got, err := DirSize(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != 400 {
+		t.Errorf("DirSize = %d, want 400", got)
+	}
+}
+
+func TestDirSize_MissingPathIsZero(t *testing.T) {
+	got, err := DirSize(filepath.Join(t.TempDir(), "does-not-exist"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("DirSize of missing path = %d, want 0", got)
+	}
+}
+
+func TestDirSize_EmptyDir(t *testing.T) {
+	got, err := DirSize(t.TempDir())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("DirSize of empty dir = %d, want 0", got)
+	}
+}
+
+func writeFile(t *testing.T, path string, size int) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, make([]byte, size), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/nodeenv/pkgmgr.go
+++ b/internal/nodeenv/pkgmgr.go
@@ -1,0 +1,79 @@
+package nodeenv
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// PackageManager identifies the Node.js package manager a project uses.
+type PackageManager string
+
+const (
+	PnpmManager PackageManager = "pnpm"
+	NpmManager  PackageManager = "npm"
+	YarnManager PackageManager = "yarn"
+	NoManager   PackageManager = "none"
+)
+
+// DetectPackageManager determines the package manager for the project rooted at
+// dir. Precedence:
+//  1. package.json "packageManager" field (e.g. "pnpm@9.1.0") — authoritative,
+//     this is the corepack-standard signal.
+//  2. Lockfile presence (pnpm-lock.yaml / yarn.lock / package-lock.json).
+//  3. NoManager when nothing indicates a manager.
+func DetectPackageManager(dir string) PackageManager {
+	if pm := managerFromPackageJSON(filepath.Join(dir, "package.json")); pm != NoManager {
+		return pm
+	}
+
+	switch {
+	case fileExists(filepath.Join(dir, "pnpm-lock.yaml")):
+		return PnpmManager
+	case fileExists(filepath.Join(dir, "yarn.lock")):
+		return YarnManager
+	case fileExists(filepath.Join(dir, "package-lock.json")):
+		return NpmManager
+	}
+
+	return NoManager
+}
+
+// managerFromPackageJSON reads the "packageManager" field. Returns NoManager if
+// the file is missing, unparsable, or the field is absent/unrecognized — these
+// are not errors, they just mean "fall through to lockfile detection".
+func managerFromPackageJSON(path string) PackageManager {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return NoManager
+	}
+
+	var pkg struct {
+		PackageManager string `json:"packageManager"`
+	}
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return NoManager
+	}
+
+	// Field looks like "pnpm@9.1.0"; only the name before "@" matters.
+	name := pkg.PackageManager
+	if i := strings.IndexByte(name, '@'); i >= 0 {
+		name = name[:i]
+	}
+	switch PackageManager(name) {
+	case PnpmManager:
+		return PnpmManager
+	case YarnManager:
+		return YarnManager
+	case NpmManager:
+		return NpmManager
+	default:
+		return NoManager
+	}
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}

--- a/internal/nodeenv/pkgmgr_test.go
+++ b/internal/nodeenv/pkgmgr_test.go
@@ -1,0 +1,80 @@
+package nodeenv
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectPackageManager(t *testing.T) {
+	tests := []struct {
+		name  string
+		files map[string]string
+		want  PackageManager
+	}{
+		{
+			name:  "packageManager field wins over lockfile",
+			files: map[string]string{"package.json": `{"packageManager":"pnpm@9.1.0"}`, "yarn.lock": ""},
+			want:  PnpmManager,
+		},
+		{
+			name:  "yarn from packageManager field",
+			files: map[string]string{"package.json": `{"packageManager":"yarn@4.0.0"}`},
+			want:  YarnManager,
+		},
+		{
+			name:  "npm from packageManager field",
+			files: map[string]string{"package.json": `{"packageManager":"npm@10.0.0"}`},
+			want:  NpmManager,
+		},
+		{
+			name:  "pnpm from lockfile",
+			files: map[string]string{"pnpm-lock.yaml": ""},
+			want:  PnpmManager,
+		},
+		{
+			name:  "yarn from lockfile",
+			files: map[string]string{"yarn.lock": ""},
+			want:  YarnManager,
+		},
+		{
+			name:  "npm from lockfile",
+			files: map[string]string{"package-lock.json": ""},
+			want:  NpmManager,
+		},
+		{
+			name:  "lockfile fallthrough when packageManager absent",
+			files: map[string]string{"package.json": `{"name":"app"}`, "pnpm-lock.yaml": ""},
+			want:  PnpmManager,
+		},
+		{
+			name:  "nothing detected",
+			files: map[string]string{"package.json": `{"name":"app"}`},
+			want:  NoManager,
+		},
+		{
+			name:  "empty dir",
+			files: map[string]string{},
+			want:  NoManager,
+		},
+		{
+			name:  "malformed package.json falls through",
+			files: map[string]string{"package.json": `{not json`, "package-lock.json": ""},
+			want:  NpmManager,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			for name, content := range tt.files {
+				if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if got := DetectPackageManager(dir); got != tt.want {
+				t.Errorf("DetectPackageManager = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/nodeenv/pnpm.go
+++ b/internal/nodeenv/pnpm.go
@@ -1,0 +1,70 @@
+package nodeenv
+
+// Config keys driftr manages on the user's global pnpm configuration.
+const (
+	// StoreDirKey points pnpm at driftr's shared content-addressable store.
+	StoreDirKey = "store-dir"
+	// GlobalVirtualStoreKey enables pnpm's global virtual store, allowing the
+	// virtual store (node_modules/.pnpm) to be shared across projects. This is
+	// a newer pnpm flag; older pnpm versions may not recognize it.
+	GlobalVirtualStoreKey = "enable-global-virtual-store"
+)
+
+// Pnpm wraps pnpm/corepack invocations through a Runner.
+type Pnpm struct {
+	r Runner
+}
+
+// NewPnpm returns a Pnpm service backed by the given Runner.
+func NewPnpm(r Runner) *Pnpm { return &Pnpm{r: r} }
+
+// Installed reports whether pnpm is resolvable on PATH.
+func (p *Pnpm) Installed() bool {
+	_, err := p.r.LookPath("pnpm")
+	return err == nil
+}
+
+// CorepackAvailable reports whether corepack is resolvable on PATH.
+func (p *Pnpm) CorepackAvailable() bool {
+	_, err := p.r.LookPath("corepack")
+	return err == nil
+}
+
+// Version returns the installed pnpm version string.
+func (p *Pnpm) Version() (string, error) {
+	return p.r.Run("pnpm", "--version")
+}
+
+// CorepackEnable runs `corepack enable`.
+func (p *Pnpm) CorepackEnable() error {
+	_, err := p.r.Run("corepack", "enable")
+	return err
+}
+
+// ConfigGet returns the global pnpm config value for key. pnpm prints
+// "undefined" for unset keys; that is returned verbatim for the caller to
+// interpret.
+func (p *Pnpm) ConfigGet(key string) (string, error) {
+	return p.r.Run("pnpm", "config", "get", key)
+}
+
+// ConfigSet writes a global pnpm config value.
+func (p *Pnpm) ConfigSet(key, value string) error {
+	_, err := p.r.Run("pnpm", "config", "set", key, value)
+	return err
+}
+
+// StorePath returns the active pnpm store path.
+func (p *Pnpm) StorePath() (string, error) {
+	return p.r.Run("pnpm", "store", "path")
+}
+
+// StorePrune removes orphaned packages from the store.
+func (p *Pnpm) StorePrune() (string, error) {
+	return p.r.Run("pnpm", "store", "prune")
+}
+
+// Install runs `pnpm install` in the current working directory.
+func (p *Pnpm) Install() (string, error) {
+	return p.r.Run("pnpm", "install")
+}

--- a/internal/nodeenv/pnpm_test.go
+++ b/internal/nodeenv/pnpm_test.go
@@ -1,0 +1,110 @@
+package nodeenv
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// fakeRunner records invocations and returns scripted output keyed by the joined
+// command line. Missing keys return empty output and no error.
+type fakeRunner struct {
+	calls    []string
+	outputs  map[string]string
+	errs     map[string]error
+	missing  map[string]bool // names that LookPath should fail for
+	lookErrs error
+}
+
+func newFakeRunner() *fakeRunner {
+	return &fakeRunner{outputs: map[string]string{}, errs: map[string]error{}, missing: map[string]bool{}}
+}
+
+func (f *fakeRunner) Run(name string, args ...string) (string, error) {
+	key := strings.TrimSpace(name + " " + strings.Join(args, " "))
+	f.calls = append(f.calls, key)
+	return f.outputs[key], f.errs[key]
+}
+
+func (f *fakeRunner) LookPath(name string) (string, error) {
+	if f.missing[name] {
+		return "", errors.New("not found")
+	}
+	return "/usr/bin/" + name, nil
+}
+
+func (f *fakeRunner) called(cmd string) bool {
+	for _, c := range f.calls {
+		if c == cmd {
+			return true
+		}
+	}
+	return false
+}
+
+func TestPnpm_Installed(t *testing.T) {
+	f := newFakeRunner()
+	if !NewPnpm(f).Installed() {
+		t.Error("expected Installed=true when pnpm on PATH")
+	}
+	f.missing["pnpm"] = true
+	if NewPnpm(f).Installed() {
+		t.Error("expected Installed=false when pnpm missing")
+	}
+}
+
+func TestPnpm_ConfigSetCommand(t *testing.T) {
+	f := newFakeRunner()
+	if err := NewPnpm(f).ConfigSet(StoreDirKey, "/store"); err != nil {
+		t.Fatal(err)
+	}
+	want := "pnpm config set store-dir /store"
+	if !f.called(want) {
+		t.Errorf("expected call %q, got %v", want, f.calls)
+	}
+}
+
+func TestPnpm_ConfigGetReturnsOutput(t *testing.T) {
+	f := newFakeRunner()
+	f.outputs["pnpm config get enable-global-virtual-store"] = "true"
+	got, err := NewPnpm(f).ConfigGet(GlobalVirtualStoreKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "true" {
+		t.Errorf("ConfigGet = %q, want %q", got, "true")
+	}
+}
+
+func TestPnpm_CorepackEnableCommand(t *testing.T) {
+	f := newFakeRunner()
+	if err := NewPnpm(f).CorepackEnable(); err != nil {
+		t.Fatal(err)
+	}
+	if !f.called("corepack enable") {
+		t.Errorf("expected 'corepack enable', got %v", f.calls)
+	}
+}
+
+func TestPnpm_StoreCommands(t *testing.T) {
+	f := newFakeRunner()
+	f.outputs["pnpm store path"] = "/store/pnpm"
+	p := NewPnpm(f)
+	if got, _ := p.StorePath(); got != "/store/pnpm" {
+		t.Errorf("StorePath = %q", got)
+	}
+	if _, err := p.StorePrune(); err != nil {
+		t.Fatal(err)
+	}
+	if !f.called("pnpm store prune") {
+		t.Errorf("expected 'pnpm store prune', got %v", f.calls)
+	}
+}
+
+func TestPnpm_RunErrorPropagates(t *testing.T) {
+	f := newFakeRunner()
+	f.errs["pnpm config set store-dir /store"] = errors.New("boom")
+	if err := NewPnpm(f).ConfigSet(StoreDirKey, "/store"); err == nil {
+		t.Error("expected error to propagate")
+	}
+}

--- a/internal/nodeenv/pnpm_test.go
+++ b/internal/nodeenv/pnpm_test.go
@@ -9,11 +9,10 @@ import (
 // fakeRunner records invocations and returns scripted output keyed by the joined
 // command line. Missing keys return empty output and no error.
 type fakeRunner struct {
-	calls    []string
-	outputs  map[string]string
-	errs     map[string]error
-	missing  map[string]bool // names that LookPath should fail for
-	lookErrs error
+	calls   []string
+	outputs map[string]string
+	errs    map[string]error
+	missing map[string]bool // names that LookPath should fail for
 }
 
 func newFakeRunner() *fakeRunner {

--- a/internal/nodeenv/runner.go
+++ b/internal/nodeenv/runner.go
@@ -1,0 +1,43 @@
+package nodeenv
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// Runner abstracts external command execution so pnpm/corepack interactions can
+// be driven by a fake in tests. The production implementation is execRunner.
+type Runner interface {
+	// Run executes name with args, returning trimmed stdout. On failure the
+	// error includes captured stderr for actionable messages.
+	Run(name string, args ...string) (string, error)
+	// LookPath reports the resolved path of name, or an error if not on PATH.
+	LookPath(name string) (string, error)
+}
+
+// execRunner is the os/exec-backed Runner used in production.
+type execRunner struct{}
+
+// NewExecRunner returns a Runner that shells out to real binaries.
+func NewExecRunner() Runner { return execRunner{} }
+
+func (execRunner) Run(name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg != "" {
+			return "", fmt.Errorf("%s %s: %w: %s", name, strings.Join(args, " "), err, msg)
+		}
+		return "", fmt.Errorf("%s %s: %w", name, strings.Join(args, " "), err)
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+func (execRunner) LookPath(name string) (string, error) {
+	return exec.LookPath(name)
+}

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -74,6 +74,25 @@ func CacheDir() (string, error) {
 	return filepath.Join(home, "cache"), nil
 }
 
+// StoresDir returns the shared package-store root (~/.driftr/stores).
+func StoresDir() (string, error) {
+	home, err := DriftrHome()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "stores"), nil
+}
+
+// PnpmStoreDir returns the pnpm content-addressable store directory
+// (~/.driftr/stores/pnpm) that driftr configures pnpm to use.
+func PnpmStoreDir() (string, error) {
+	stores, err := StoresDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(stores, "pnpm"), nil
+}
+
 // GlobalConfigPath returns the path to the global config file.
 func GlobalConfigPath() (string, error) {
 	home, err := DriftrHome()

--- a/test.sh
+++ b/test.sh
@@ -150,6 +150,17 @@ check "pnpx shim was created" test -f "$HOME/.driftr/bin/pnpx"
 check "yarn shim was created" test -f "$HOME/.driftr/bin/yarn"
 echo
 
+# ── 14. Node Shared Storage ─────────────────
+# pnpm/corepack are not guaranteed in the test image, so only cover the
+# pnpm-free paths: help registration and clean's dry-run (mutates nothing).
+echo -e "${BLUE}[14] Node Shared Storage${NC}"
+mkdir -p /tmp/test-node && cd /tmp/test-node || exit 1
+check_output "node group help lists subcommands" "optimize" driftr node --help
+check_output "node clean defaults to dry-run" "Dry run" driftr node clean
+check "node clean dry-run creates no node_modules" sh -c '! test -d /tmp/test-node/node_modules'
+cd /home/driftr || exit 1
+echo
+
 # ── Summary ───────────────────────────────────
 echo ""
 echo -e "${BLUE}═══════════════════════════════════════${NC}"


### PR DESCRIPTION
Adds a `driftr node` command group that optimizes pnpm's shared content-addressable store across projects, instead of replacing package managers.

`node` is a parent group — each command is invoked with the full path, e.g. `driftr node doctor`.

## Commands
- `driftr node doctor` — analyze package manager + pnpm store config, recommend optimizations (read-only, degrades when pnpm absent)
- `driftr node optimize [--install]` — idempotent: corepack enable + `store-dir`=`~/.driftr/stores/pnpm` + `enable-global-virtual-store`
- `driftr node clean [--yes]` — dry-run by default; `--yes` removes node_modules, reinstalls, prunes store
- `driftr node report` — project node_modules size vs shared store size (single-project scope, no fabricated savings)

## Implementation
- New `internal/nodeenv/` package: `Runner` interface over `os/exec` (pnpm/corepack mockable in tests), package-manager detection, native `filepath.Walk` disk sizing
- `platform.StoresDir`/`PnpmStoreDir` helpers; `formatSize` extended with GB tier
- Distinct from existing top-level `driftr doctor` (which checks the driftr install)

## Tests & docs
- Unit tests: nodeenv (sizing, detection, pnpm command assertions) + cli (optimize idempotency, clean dry-run/execute, doctor render, report)
- Light `test.sh` integration coverage (help + clean dry-run, pnpm-free)
- README updated with command table + `driftr node` section