### PR TITLE
feat: colorize CLI output

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ pnpm -v   # resolves automatically
 
 All commands support `-v` / `--verbose` for detailed output including resolver tracing and checksum details.
 
+Output is colorized when writing to a terminal. Color is disabled automatically when output is piped/redirected, or when the [`NO_COLOR`](https://no-color.org/) environment variable is set.
+
 ### Shared dependency storage (`driftr node`)
 
 Driftr does not replace pnpm/npm/yarn. The `driftr node` commands configure and

--- a/internal/cli/cache.go
+++ b/internal/cli/cache.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/DriftrLabs/driftr/internal/ioutil"
 	"github.com/DriftrLabs/driftr/internal/platform"
 )
 
@@ -37,14 +38,14 @@ func newCacheCleanCmd() *cobra.Command {
 			entries, err := os.ReadDir(cacheDir)
 			if err != nil {
 				if errors.Is(err, os.ErrNotExist) {
-					fmt.Println("Cache is already empty.")
+					fmt.Println(ioutil.Dim("Cache is already empty."))
 					return nil
 				}
 				return fmt.Errorf("failed to read cache directory: %w", err)
 			}
 
 			if len(entries) == 0 {
-				fmt.Println("Cache is already empty.")
+				fmt.Println(ioutil.Dim("Cache is already empty."))
 				return nil
 			}
 
@@ -63,11 +64,11 @@ func newCacheCleanCmd() *cobra.Command {
 				return fmt.Errorf("failed to clean cache: %w", err)
 			}
 
-			summary := fmt.Sprintf("Removed %d cached file(s), freed %s", len(entries), formatSize(totalSize))
+			summary := fmt.Sprintf("Removed %d cached file(s), freed %s", len(entries), ioutil.Bold(formatSize(totalSize)))
 			if unsized > 0 {
 				summary += fmt.Sprintf(" (size of %d file(s) unknown)", unsized)
 			}
-			fmt.Println(summary + ".")
+			fmt.Println(ioutil.Success(summary + "."))
 			return nil
 		},
 	}

--- a/internal/cli/default.go
+++ b/internal/cli/default.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/DriftrLabs/driftr/internal/config"
+	"github.com/DriftrLabs/driftr/internal/ioutil"
 	"github.com/DriftrLabs/driftr/internal/resolver"
 )
 
@@ -33,7 +34,7 @@ func newDefaultCmd() *cobra.Command {
 				return err
 			}
 
-			fmt.Printf("Set global default to %s %s\n", tool, versionStr)
+			fmt.Println(ioutil.Success(fmt.Sprintf("Set global default to %s %s", tool, ioutil.Bold(versionStr))))
 			return nil
 		},
 	}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/DriftrLabs/driftr/internal/config"
+	"github.com/DriftrLabs/driftr/internal/ioutil"
 	"github.com/DriftrLabs/driftr/internal/pathsetup"
 	"github.com/DriftrLabs/driftr/internal/platform"
 	"github.com/DriftrLabs/driftr/internal/shim"
@@ -60,9 +61,9 @@ func newDoctorCmd() *cobra.Command {
 
 			fmt.Println()
 			if issues == 0 {
-				fmt.Println("No issues found.")
+				fmt.Println(ioutil.Success(ioutil.Bold("No issues found.")))
 			} else {
-				fmt.Printf("Found %d issue(s).\n", issues)
+				fmt.Println(ioutil.Warn(fmt.Sprintf("Found %d issue(s).", issues)))
 			}
 			return nil
 		},
@@ -72,11 +73,11 @@ func newDoctorCmd() *cobra.Command {
 }
 
 func pass(msg string) {
-	fmt.Printf("  ok  %s\n", msg)
+	fmt.Printf("  %s  %s\n", ioutil.Green("ok"), msg)
 }
 
 func warn(msg string) {
-	fmt.Printf("  !!  %s\n", msg)
+	fmt.Printf("  %s  %s\n", ioutil.Yellow("!!"), msg)
 }
 
 func checkPath(binDir string) int {

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/DriftrLabs/driftr/internal/installer"
+	"github.com/DriftrLabs/driftr/internal/ioutil"
 )
 
 func newInstallCmd() *cobra.Command {
@@ -18,14 +19,14 @@ func newInstallCmd() *cobra.Command {
 			spec := args[0]
 			tool, versionSpec := parseToolVersion(spec)
 
-			fmt.Printf("Installing %s...\n", spec)
+			fmt.Println(ioutil.Dim(fmt.Sprintf("Installing %s...", spec)))
 
 			resolved, err := installTool(tool, versionSpec, verbose)
 			if err != nil {
 				return fmt.Errorf("installation failed: %w", err)
 			}
 
-			fmt.Printf("Installed %s %s\n", tool, resolved)
+			fmt.Println(ioutil.Success(fmt.Sprintf("Installed %s %s", tool, ioutil.Bold(resolved))))
 			return nil
 		},
 	}

--- a/internal/cli/node_clean.go
+++ b/internal/cli/node_clean.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/DriftrLabs/driftr/internal/ioutil"
 	"github.com/DriftrLabs/driftr/internal/nodeenv"
 )
 
@@ -46,15 +47,16 @@ func runNodeClean(p *nodeenv.Pnpm, projectDir string, doExecute bool, w io.Write
 	size, _ := nodeenv.DirSize(nodeModules)
 
 	if !doExecute {
-		fmt.Fprintln(w, "Dry run — no changes made. Re-run with --yes to execute.")
+		fmt.Fprintln(w, ioutil.Title("Dry run"))
+		fmt.Fprintln(w, ioutil.Dim("No changes made. Re-run with --yes to execute."))
 		fmt.Fprintln(w)
 		if hasNodeModules {
-			fmt.Fprintf(w, "Would remove: %s (%s)\n", nodeModules, formatSize(size))
-			fmt.Fprintln(w, "Would run:    pnpm install")
+			fmt.Fprintf(w, "Would remove: %s %s\n", nodeModules, ioutil.Dim("("+formatSize(size)+")"))
+			fmt.Fprintf(w, "Would run:    %s\n", ioutil.Bold("pnpm install"))
 		} else {
-			fmt.Fprintln(w, "No node_modules to remove.")
+			fmt.Fprintln(w, ioutil.Bullet("no node_modules to remove"))
 		}
-		fmt.Fprintln(w, "Would run:    pnpm store prune")
+		fmt.Fprintf(w, "Would run:    %s\n", ioutil.Bold("pnpm store prune"))
 		return nil
 	}
 
@@ -62,16 +64,16 @@ func runNodeClean(p *nodeenv.Pnpm, projectDir string, doExecute bool, w io.Write
 		if err := os.RemoveAll(nodeModules); err != nil {
 			return fmt.Errorf("removing node_modules: %w", err)
 		}
-		fmt.Fprintf(w, "✓ removed node_modules (%s)\n", formatSize(size))
+		fmt.Fprintln(w, ioutil.Success("removed node_modules "+ioutil.Dim("("+formatSize(size)+")")))
 	} else {
-		fmt.Fprintln(w, "• no node_modules to remove")
+		fmt.Fprintln(w, ioutil.Bullet("no node_modules to remove"))
 	}
 
 	// Reinstall and prune require pnpm. If it is missing, the node_modules
 	// removal above still succeeded — warn rather than fail outright.
 	if !p.Installed() {
-		fmt.Fprintln(w, "⚠ pnpm not found — skipped reinstall and store prune.")
-		fmt.Fprintln(w, "  Run 'corepack enable', then 'pnpm install' to restore dependencies.")
+		fmt.Fprintln(w, ioutil.Warn("pnpm not found — skipped reinstall and store prune."))
+		fmt.Fprintln(w, ioutil.Dim("  Run 'corepack enable', then 'pnpm install' to restore dependencies."))
 		return nil
 	}
 
@@ -80,12 +82,12 @@ func runNodeClean(p *nodeenv.Pnpm, projectDir string, doExecute bool, w io.Write
 		if _, err := p.Install(); err != nil {
 			return fmt.Errorf("pnpm install failed: %w", err)
 		}
-		fmt.Fprintln(w, "✓ dependencies reinstalled")
+		fmt.Fprintln(w, ioutil.Success("dependencies reinstalled"))
 	}
 
 	if _, err := p.StorePrune(); err != nil {
 		return fmt.Errorf("pnpm store prune failed: %w", err)
 	}
-	fmt.Fprintln(w, "✓ pruned orphaned packages from the shared store")
+	fmt.Fprintln(w, ioutil.Success("pruned orphaned packages from the shared store"))
 	return nil
 }

--- a/internal/cli/node_doctor.go
+++ b/internal/cli/node_doctor.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/DriftrLabs/driftr/internal/ioutil"
 	"github.com/DriftrLabs/driftr/internal/nodeenv"
 )
 
@@ -79,68 +80,78 @@ func gatherNodeDoctor(r nodeenv.Runner, projectDir string) nodeDoctorInfo {
 }
 
 func renderNodeDoctor(w io.Writer, info nodeDoctorInfo) {
-	fmt.Fprintln(w, "Driftr Node Doctor")
+	row := func(label, value string) {
+		// Pad the plain label before coloring so alignment is unaffected by
+		// the (zero-width at runtime) ANSI escape codes.
+		fmt.Fprintf(w, "%s %s\n", ioutil.Label(fmt.Sprintf("%-21s", label)), value)
+	}
+
+	fmt.Fprintln(w, ioutil.Title("Driftr Node Doctor"))
 	fmt.Fprintln(w)
-	fmt.Fprintf(w, "Project:         %s\n", info.projectDir)
-	fmt.Fprintf(w, "Package manager: %s\n", info.packageManager)
-	fmt.Fprintf(w, "Node.js:         %s\n", orNotFound(info.nodeVersion))
-	fmt.Fprintf(w, "Corepack:        %s\n", availability(info.corepackAvailable))
+	row("Project:", info.projectDir)
+	row("Package manager:", string(info.packageManager))
+	row("Node.js:", orNotFound(info.nodeVersion))
+	row("Corepack:", availability(info.corepackAvailable))
 
 	if info.pnpmInstalled {
-		fmt.Fprintf(w, "pnpm:            %s\n", orNotFound(info.pnpmVersion))
+		row("pnpm:", orNotFound(info.pnpmVersion))
 	} else {
-		fmt.Fprintf(w, "pnpm:            not found\n")
+		row("pnpm:", ioutil.Red("not found"))
 	}
 
 	if info.nodeModulesSize > 0 {
-		fmt.Fprintf(w, "node_modules:    %s\n", formatSize(info.nodeModulesSize))
+		row("node_modules:", formatSize(info.nodeModulesSize))
 	} else {
-		fmt.Fprintf(w, "node_modules:    none\n")
+		row("node_modules:", ioutil.Dim("none"))
 	}
 
-	fmt.Fprintf(w, "pnpm store:      %s\n", orUnknown(info.storePath))
-	fmt.Fprintf(w, "global virtual store: %s\n", enabledDisabled(info.globalVirtualStore))
+	row("pnpm store:", orUnknown(info.storePath))
+	row("global virtual store:", enabledDisabled(info.globalVirtualStore))
 
 	if !info.pnpmInstalled {
 		fmt.Fprintln(w)
-		fmt.Fprintln(w, "Recommendation:")
+		fmt.Fprintln(w, ioutil.Warn("Recommendation"))
 		fmt.Fprintln(w, "pnpm is not installed. Enable corepack to get it, then optimize storage.")
-		fmt.Fprintln(w, "Run: corepack enable && driftr node optimize")
+		fmt.Fprintf(w, "Run: %s\n", ioutil.Bold("corepack enable && driftr node optimize"))
 		return
 	}
 
 	if !info.globalVirtualStore {
 		fmt.Fprintln(w)
-		fmt.Fprintln(w, "Recommendation:")
+		fmt.Fprintln(w, ioutil.Warn("Recommendation"))
 		fmt.Fprintln(w, "Enable pnpm shared storage to reduce duplicated dependency data.")
-		fmt.Fprintln(w, "Run: driftr node optimize")
+		fmt.Fprintf(w, "Run: %s\n", ioutil.Bold("driftr node optimize"))
+		return
 	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, ioutil.Success("Shared dependency storage is enabled."))
 }
 
 func orNotFound(s string) string {
 	if s == "" {
-		return "not found"
+		return ioutil.Red("not found")
 	}
 	return s
 }
 
 func orUnknown(s string) string {
 	if s == "" {
-		return "unknown"
+		return ioutil.Dim("unknown")
 	}
 	return s
 }
 
 func availability(ok bool) string {
 	if ok {
-		return "available"
+		return ioutil.Green("available")
 	}
-	return "not found"
+	return ioutil.Red("not found")
 }
 
 func enabledDisabled(on bool) string {
 	if on {
-		return "enabled"
+		return ioutil.Green("enabled")
 	}
-	return "disabled"
+	return ioutil.Yellow("disabled")
 }

--- a/internal/cli/node_optimize.go
+++ b/internal/cli/node_optimize.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/DriftrLabs/driftr/internal/ioutil"
 	"github.com/DriftrLabs/driftr/internal/nodeenv"
 	"github.com/DriftrLabs/driftr/internal/platform"
 )
@@ -35,7 +36,7 @@ func newNodeOptimizeCmd() *cobra.Command {
 // runNodeOptimize applies the shared-store configuration idempotently. Returns
 // an actionable error when pnpm is unavailable.
 func runNodeOptimize(p *nodeenv.Pnpm, storeDir string, install bool, w io.Writer) error {
-	fmt.Fprintln(w, "Optimizing pnpm shared dependency storage...")
+	fmt.Fprintln(w, ioutil.Title("Optimizing pnpm shared dependency storage"))
 	fmt.Fprintln(w)
 
 	// corepack runs first: enabling it can make pnpm resolvable, so the pnpm
@@ -44,9 +45,9 @@ func runNodeOptimize(p *nodeenv.Pnpm, storeDir string, install bool, w io.Writer
 		if err := p.CorepackEnable(); err != nil {
 			return fmt.Errorf("corepack enable failed: %w", err)
 		}
-		fmt.Fprintln(w, "✓ corepack enabled")
+		fmt.Fprintln(w, ioutil.Success("corepack enabled"))
 	} else {
-		fmt.Fprintln(w, "• corepack not found, skipping")
+		fmt.Fprintln(w, ioutil.Bullet("corepack not found, skipping"))
 	}
 
 	if !p.Installed() {
@@ -63,13 +64,13 @@ func runNodeOptimize(p *nodeenv.Pnpm, storeDir string, install bool, w io.Writer
 			return fmt.Errorf("reading pnpm config %q: %w", t.key, err)
 		}
 		if current == t.value {
-			fmt.Fprintf(w, "• %s already %s\n", t.key, t.value)
+			fmt.Fprintln(w, ioutil.Bullet(fmt.Sprintf("%s already %s", t.key, t.value)))
 			continue
 		}
 		if err := p.ConfigSet(t.key, t.value); err != nil {
 			return fmt.Errorf("setting pnpm config %q: %w", t.key, err)
 		}
-		fmt.Fprintf(w, "✓ set %s = %s\n", t.key, t.value)
+		fmt.Fprintln(w, ioutil.Success(fmt.Sprintf("set %s = %s", t.key, ioutil.Bold(t.value))))
 	}
 
 	if install {
@@ -78,10 +79,10 @@ func runNodeOptimize(p *nodeenv.Pnpm, storeDir string, install bool, w io.Writer
 		if _, err := p.Install(); err != nil {
 			return fmt.Errorf("pnpm install failed: %w", err)
 		}
-		fmt.Fprintln(w, "✓ dependencies installed")
+		fmt.Fprintln(w, ioutil.Success("dependencies installed"))
 	}
 
 	fmt.Fprintln(w)
-	fmt.Fprintln(w, "Done. Dependencies are now stored in the shared pnpm store.")
+	fmt.Fprintln(w, ioutil.Green("Done. Dependencies are now stored in the shared pnpm store."))
 	return nil
 }

--- a/internal/cli/node_report.go
+++ b/internal/cli/node_report.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/DriftrLabs/driftr/internal/ioutil"
 	"github.com/DriftrLabs/driftr/internal/nodeenv"
 )
 
@@ -53,17 +54,21 @@ func runNodeReport(p *nodeenv.Pnpm, projectDir string, w io.Writer) error {
 		}
 	}
 
-	fmt.Fprintln(w, "Driftr Storage Report")
+	row := func(label, value string) {
+		fmt.Fprintf(w, "%s %s\n", ioutil.Label(fmt.Sprintf("%-21s", label)), value)
+	}
+
+	fmt.Fprintln(w, ioutil.Title("Driftr Storage Report"))
 	fmt.Fprintln(w)
-	fmt.Fprintf(w, "Project:               %s\n", projectDir)
-	fmt.Fprintf(w, "Project node_modules:  %s\n", formatSize(nodeModulesSize))
+	row("Project:", projectDir)
+	row("Project node_modules:", ioutil.Bold(formatSize(nodeModulesSize)))
 	if storeKnown {
-		fmt.Fprintf(w, "Shared pnpm store:     %s\n", formatSize(storeSize))
+		row("Shared pnpm store:", ioutil.Bold(formatSize(storeSize)))
 	} else {
-		fmt.Fprintf(w, "Shared pnpm store:     %s\n", storeNote)
+		row("Shared pnpm store:", ioutil.Dim(storeNote))
 	}
 	fmt.Fprintln(w)
-	fmt.Fprintln(w, "The shared pnpm store is reused across every project on this machine,")
-	fmt.Fprintln(w, "so its cost is amortized — more projects means greater savings overall.")
+	fmt.Fprintln(w, ioutil.Dim("The shared pnpm store is reused across every project on this machine,"))
+	fmt.Fprintln(w, ioutil.Dim("so its cost is amortized — more projects means greater savings overall."))
 	return nil
 }

--- a/internal/cli/node_test.go
+++ b/internal/cli/node_test.go
@@ -215,6 +215,35 @@ func TestGatherNodeDoctor_RecommendsOptimizeWhenDisabled(t *testing.T) {
 	}
 }
 
+func TestRenderNodeDoctor_PnpmMissingRecommendsCorepack(t *testing.T) {
+	var buf bytes.Buffer
+	renderNodeDoctor(&buf, nodeDoctorInfo{projectDir: "/p", pnpmInstalled: false})
+	out := buf.String()
+	if !strings.Contains(out, "corepack enable") {
+		t.Errorf("expected corepack recommendation, got: %s", out)
+	}
+	if !strings.Contains(out, "not found") {
+		t.Errorf("expected pnpm 'not found', got: %s", out)
+	}
+}
+
+func TestRenderNodeDoctor_AllGoodSuccess(t *testing.T) {
+	var buf bytes.Buffer
+	renderNodeDoctor(&buf, nodeDoctorInfo{
+		projectDir:         "/p",
+		pnpmInstalled:      true,
+		pnpmVersion:        "9.1.0",
+		globalVirtualStore: true,
+	})
+	out := buf.String()
+	if strings.Contains(out, "Recommendation") {
+		t.Errorf("no recommendation expected when already optimized, got: %s", out)
+	}
+	if !strings.Contains(out, "enabled") {
+		t.Errorf("expected enabled confirmation, got: %s", out)
+	}
+}
+
 func TestRunNodeReport_ShowsSizes(t *testing.T) {
 	dir := t.TempDir()
 	store := t.TempDir()

--- a/internal/cli/pin.go
+++ b/internal/cli/pin.go
@@ -126,7 +126,7 @@ func savePin(dir, tool, versionStr string, format pinFormat) error {
 		if err := config.SavePackageJSONTool(dir, tool, versionStr); err != nil {
 			return err
 		}
-		fmt.Printf("Pinned %s %s in %s/package.json\n", tool, versionStr, dir)
+		fmt.Println(ioutil.Success(fmt.Sprintf("Pinned %s %s in %s/package.json", tool, ioutil.Bold(versionStr), dir)))
 	default:
 		cfg, err := config.LoadProject(dir)
 		if err != nil {
@@ -139,7 +139,7 @@ func savePin(dir, tool, versionStr string, format pinFormat) error {
 		if err := config.SaveProject(dir, cfg); err != nil {
 			return err
 		}
-		fmt.Printf("Pinned %s %s in %s/%s\n", tool, versionStr, dir, config.ProjectConfigFile)
+		fmt.Println(ioutil.Success(fmt.Sprintf("Pinned %s %s in %s/%s", tool, ioutil.Bold(versionStr), dir, config.ProjectConfigFile)))
 	}
 	return nil
 }
@@ -155,7 +155,7 @@ func migratePin(dir, tool, versionStr string, current pinFormat) error {
 		if err := os.Remove(filepath.Join(dir, config.ProjectConfigFile)); err != nil {
 			return fmt.Errorf("migrated to package.json but failed to remove %s: %w. Remove it manually — it takes precedence over package.json", config.ProjectConfigFile, err)
 		}
-		fmt.Printf("Migrated %s %s from %s to package.json\n", tool, versionStr, config.ProjectConfigFile)
+		fmt.Println(ioutil.Success(fmt.Sprintf("Migrated %s %s from %s to package.json", tool, ioutil.Bold(versionStr), config.ProjectConfigFile)))
 
 	case formatPackageJSON:
 		// Migrate package.json → TOML.
@@ -167,7 +167,7 @@ func migratePin(dir, tool, versionStr string, current pinFormat) error {
 		if err := config.RemoveDriftrFromPackageJSON(dir); err != nil {
 			return err
 		}
-		fmt.Printf("Migrated %s %s from package.json to %s\n", tool, versionStr, config.ProjectConfigFile)
+		fmt.Println(ioutil.Success(fmt.Sprintf("Migrated %s %s from package.json to %s", tool, ioutil.Bold(versionStr), config.ProjectConfigFile)))
 
 	case formatNone:
 		return fmt.Errorf("no existing config to migrate. Run `driftr pin %s@<version>` first", tool)

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/DriftrLabs/driftr/internal/ioutil"
 	"github.com/DriftrLabs/driftr/internal/platform"
 	"github.com/DriftrLabs/driftr/internal/shim"
 )
@@ -28,13 +29,13 @@ func newSetupCmd() *cobra.Command {
 				return err
 			}
 
-			fmt.Println("Driftr setup complete!")
+			fmt.Println(ioutil.Success(ioutil.Bold("Driftr setup complete!")))
 			fmt.Println()
 			fmt.Println("Add the following to your shell profile (~/.zshrc, ~/.bashrc, etc.):")
 			fmt.Println()
-			fmt.Printf("  export PATH=\"%s:$PATH\"\n", binDir)
+			fmt.Printf("  %s\n", ioutil.Bold(fmt.Sprintf("export PATH=\"%s:$PATH\"", binDir)))
 			fmt.Println()
-			fmt.Println("Then restart your shell or run: source ~/.zshrc")
+			fmt.Println(ioutil.Dim("Then restart your shell or run: source ~/.zshrc"))
 
 			return nil
 		},

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/DriftrLabs/driftr/internal/config"
+	"github.com/DriftrLabs/driftr/internal/ioutil"
 	"github.com/DriftrLabs/driftr/internal/platform"
 	"github.com/DriftrLabs/driftr/internal/version"
 )
@@ -54,29 +55,29 @@ func newUninstallCmd() *cobra.Command {
 			// Warn if this is the global default.
 			cfg, err := config.LoadGlobal()
 			if err == nil && cfg.Default.GetTool(tool) == versionStr {
-				fmt.Printf("Warning: %s %s is the current global default. Run `driftr default %s@<version>` to set a new one.\n", tool, versionStr, tool)
+				fmt.Println(ioutil.Warn(fmt.Sprintf("%s %s is the current global default. Run `driftr default %s@<version>` to set a new one.", tool, versionStr, tool)))
 			}
 
 			// Warn if this version is pinned in the project config.
 			cwd, cwdErr := os.Getwd()
 			if cwdErr == nil {
 				if proj, err := config.LoadProject(cwd); err == nil && proj != nil && proj.Tools.GetTool(tool) == versionStr {
-					fmt.Printf("Warning: %s@%s is pinned in .driftr.toml — uninstalling will break this project until you run 'driftr install %s@%s' or update the pin\n", tool, versionStr, tool, versionStr)
+					fmt.Println(ioutil.Warn(fmt.Sprintf("%s@%s is pinned in .driftr.toml — uninstalling will break this project until you run 'driftr install %s@%s' or update the pin", tool, versionStr, tool, versionStr)))
 				}
 				if pkg, err := config.LoadPackageJSON(cwd); err == nil && pkg != nil && pkg.Driftr.GetTool(tool) == versionStr {
-					fmt.Printf("Warning: %s@%s is pinned in package.json — uninstalling will break this project until you run 'driftr install %s@%s' or update the pin\n", tool, versionStr, tool, versionStr)
+					fmt.Println(ioutil.Warn(fmt.Sprintf("%s@%s is pinned in package.json — uninstalling will break this project until you run 'driftr install %s@%s' or update the pin", tool, versionStr, tool, versionStr)))
 				}
 			}
 
 			if verbose {
-				fmt.Printf("  Removing: %s\n", versionDir)
+				fmt.Println(ioutil.Dim(fmt.Sprintf("  Removing: %s", versionDir)))
 			}
 
 			if err := os.RemoveAll(versionDir); err != nil {
 				return fmt.Errorf("failed to remove %s %s: %w. Manual cleanup: rm -rf %q", tool, versionStr, err, versionDir)
 			}
 
-			fmt.Printf("Uninstalled %s %s\n", tool, versionStr)
+			fmt.Println(ioutil.Success(fmt.Sprintf("Uninstalled %s %s", tool, ioutil.Bold(versionStr))))
 			return nil
 		},
 	}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/DriftrLabs/driftr/internal/ioutil"
 	"github.com/DriftrLabs/driftr/internal/pathsetup"
 	"github.com/DriftrLabs/driftr/internal/platform"
 	"github.com/DriftrLabs/driftr/internal/updater"
@@ -24,9 +25,9 @@ func newUpdateCmd() *cobra.Command {
 			}
 
 			if newVersion == "" {
-				fmt.Printf("driftr v%s is already the latest version.\n", Version)
+				fmt.Println(ioutil.Dim(fmt.Sprintf("driftr v%s is already the latest version.", Version)))
 			} else {
-				fmt.Printf("Updated successfully to driftr v%s!\n", newVersion)
+				fmt.Println(ioutil.Success(fmt.Sprintf("Updated successfully to driftr %s!", ioutil.Bold("v"+newVersion))))
 				migratePathConfig()
 			}
 			return nil
@@ -54,8 +55,8 @@ func migratePathConfig() {
 	if err != nil || !wrote {
 		return
 	}
-	fmt.Printf("Migrated PATH config to %s for universal shell coverage.\n", file)
+	fmt.Println(ioutil.Success(fmt.Sprintf("Migrated PATH config to %s for universal shell coverage.", file)))
 	if len(r.StaleFiles) > 0 {
-		fmt.Printf("  Note: legacy entries remain in %s — safe to remove.\n", strings.Join(r.StaleFiles, ", "))
+		fmt.Println(ioutil.Dim(fmt.Sprintf("  Note: legacy entries remain in %s — safe to remove.", strings.Join(r.StaleFiles, ", "))))
 	}
 }

--- a/internal/cli/which.go
+++ b/internal/cli/which.go
@@ -29,12 +29,17 @@ func newWhichCmd() *cobra.Command {
 				return err
 			}
 
-			fmt.Printf("%s %s\n", ioutil.Label("Tool:   "), tool)
-			fmt.Printf("%s %s\n", ioutil.Label("Version:"), ioutil.Bold(res.Version))
-			fmt.Printf("%s %s\n", ioutil.Label("Binary: "), ioutil.Green(binPath))
-			fmt.Printf("%s %s\n", ioutil.Label("Source: "), res.Source)
+			row := func(label, value string) {
+				// Pad the plain label before coloring so the (runtime zero-width)
+				// ANSI codes don't throw off column alignment.
+				fmt.Printf("%s %s\n", ioutil.Label(fmt.Sprintf("%-8s", label)), value)
+			}
+			row("Tool:", tool)
+			row("Version:", ioutil.Bold(res.Version))
+			row("Binary:", ioutil.Green(binPath))
+			row("Source:", fmt.Sprint(res.Source))
 			if res.ProjectDir != "" {
-				fmt.Printf("%s %s\n", ioutil.Label("Project:"), res.ProjectDir)
+				row("Project:", res.ProjectDir)
 			}
 
 			return nil

--- a/internal/cli/which.go
+++ b/internal/cli/which.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/DriftrLabs/driftr/internal/ioutil"
 	"github.com/DriftrLabs/driftr/internal/platform"
 	"github.com/DriftrLabs/driftr/internal/resolver"
 )
@@ -28,12 +29,12 @@ func newWhichCmd() *cobra.Command {
 				return err
 			}
 
-			fmt.Printf("Tool:    %s\n", tool)
-			fmt.Printf("Version: %s\n", res.Version)
-			fmt.Printf("Binary:  %s\n", binPath)
-			fmt.Printf("Source:  %s\n", res.Source)
+			fmt.Printf("%s %s\n", ioutil.Label("Tool:   "), tool)
+			fmt.Printf("%s %s\n", ioutil.Label("Version:"), ioutil.Bold(res.Version))
+			fmt.Printf("%s %s\n", ioutil.Label("Binary: "), ioutil.Green(binPath))
+			fmt.Printf("%s %s\n", ioutil.Label("Source: "), res.Source)
 			if res.ProjectDir != "" {
-				fmt.Printf("Project: %s\n", res.ProjectDir)
+				fmt.Printf("%s %s\n", ioutil.Label("Project:"), res.ProjectDir)
 			}
 
 			return nil

--- a/internal/ioutil/color.go
+++ b/internal/ioutil/color.go
@@ -74,8 +74,9 @@ func Title(s string) string { return Bold(Cyan(s)) }
 // Success prefixes a green check mark.
 func Success(s string) string { return Green("✓ ") + s }
 
-// Warn prefixes a yellow warning sign.
-func Warn(s string) string { return Yellow("⚠ " + s) }
+// Warn prefixes a yellow warning sign, matching Success/Failure which color
+// only the marker and leave the message in the default weight.
+func Warn(s string) string { return Yellow("⚠ ") + s }
 
 // Failure prefixes a red cross.
 func Failure(s string) string { return Red("✗ ") + s }

--- a/internal/ioutil/color.go
+++ b/internal/ioutil/color.go
@@ -42,3 +42,46 @@ func Dim(s string) string {
 	}
 	return colorize(s, "2")
 }
+
+func Yellow(s string) string {
+	if !colorEnabled() {
+		return s
+	}
+	return colorize(s, "33")
+}
+
+func Red(s string) string {
+	if !colorEnabled() {
+		return s
+	}
+	return colorize(s, "31")
+}
+
+func Cyan(s string) string {
+	if !colorEnabled() {
+		return s
+	}
+	return colorize(s, "36")
+}
+
+// Semantic helpers build a consistent vocabulary across commands. They compose
+// the primitives above so callers express intent ("this is a success line")
+// rather than a color. All degrade to plain text when color is disabled.
+
+// Title formats a section heading (bold cyan).
+func Title(s string) string { return Bold(Cyan(s)) }
+
+// Success prefixes a green check mark.
+func Success(s string) string { return Green("✓ ") + s }
+
+// Warn prefixes a yellow warning sign.
+func Warn(s string) string { return Yellow("⚠ " + s) }
+
+// Failure prefixes a red cross.
+func Failure(s string) string { return Red("✗ ") + s }
+
+// Bullet prefixes a dim bullet for secondary/no-op lines.
+func Bullet(s string) string { return Dim("• " + s) }
+
+// Label dims a field label so values stand out next to it.
+func Label(s string) string { return Dim(s) }

--- a/internal/ioutil/color_test.go
+++ b/internal/ioutil/color_test.go
@@ -32,6 +32,37 @@ func TestColorDisabled_NO_COLOR(t *testing.T) {
 	if Dim("x") != "x" {
 		t.Error("Dim() should return plain text when NO_COLOR is set")
 	}
+	if Yellow("x") != "x" || Red("x") != "x" || Cyan("x") != "x" {
+		t.Error("Yellow/Red/Cyan should return plain text when NO_COLOR is set")
+	}
+}
+
+func TestSemanticHelpers_PlainWhenDisabled(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+
+	for name, got := range map[string]string{
+		"Title":   Title("Heading"),
+		"Success": Success("done"),
+		"Warn":    Warn("careful"),
+		"Failure": Failure("nope"),
+		"Bullet":  Bullet("skipped"),
+		"Label":   Label("Key:"),
+	} {
+		if strings.Contains(got, "\033") {
+			t.Errorf("%s should not emit ANSI when color disabled, got %q", name, got)
+		}
+	}
+
+	// Prefixes/markers must survive regardless of color state.
+	if !strings.HasPrefix(Success("done"), "✓ ") {
+		t.Errorf("Success missing check mark: %q", Success("done"))
+	}
+	if !strings.HasPrefix(Warn("x"), "⚠ ") {
+		t.Errorf("Warn missing sign: %q", Warn("x"))
+	}
+	if !strings.HasPrefix(Bullet("x"), "• ") {
+		t.Errorf("Bullet missing marker: %q", Bullet("x"))
+	}
 }
 
 func TestColorDisabled_NonTTY(t *testing.T) {


### PR DESCRIPTION
Makes the CLI more UI-friendly with consistent color and status markers across all commands. Reuses the existing `internal/ioutil` color layer (TTY + NO_COLOR aware) rather than adding a dependency.

## What changed
- **`internal/ioutil`**: added `Yellow`/`Red`/`Cyan` primitives and semantic helpers — `Title`, `Success` (✓), `Warn` (⚠), `Failure` (✗), `Bullet` (•), `Label`. Each composes the primitives so callers express intent, not a color.
- **`driftr node` commands**: bold-cyan titles, status-colored values (green=ok, yellow=disabled, red=not found), green check / dim bullet for actions, yellow recommendations.
- **Other commands** (install, default, pin, uninstall, setup, which, update, cache, doctor): success lines green, warnings yellow, secondary text dimmed; top-level `doctor` `ok`/`!!` markers colorized.

## Safety
- Color degrades to plain text when stdout is not a terminal (piped/redirected) or when [`NO_COLOR`](https://no-color.org/) is set — verified both paths.
- Existing tests use buffers (non-TTY) so output stays plain; all asserts unaffected.

## Tests & docs
- New `ioutil` tests: NO_COLOR strips new primitives; semantic helpers stay plain + keep their markers when color is off.
- README notes colorized output + NO_COLOR support.