### PR TITLE
fix: install latest when given a bare tool name

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pnpm -v   # resolves automatically
 
 | Command | Description |
 |---------|-------------|
-| `driftr install <tool@version>` | Download and install a tool version (node, pnpm, yarn) |
+| `driftr install <tool[@version]>` | Download and install a tool version (node, pnpm, yarn); a bare tool name installs the latest |
 | `driftr uninstall <tool@version>` | Remove an installed tool version |
 | `driftr default <tool@version>` | Set the global default version for a tool |
 | `driftr pin <tool@version>` | Pin a version to the current project (`.driftr.toml` or `package.json`) |

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -241,3 +241,14 @@ func TestListCmd_Empty(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
+
+func TestInstallCmd_TrailingAtErrors(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	// "pnpm@" is a malformed spec — an explicit "@" with no version. It must
+	// error (offline, before any download) rather than installing latest.
+	err := runCmd(t, "install", "pnpm@")
+	if err == nil || !strings.Contains(err.Error(), "version required after '@'") {
+		t.Errorf("expected version-required error for 'pnpm@', got: %v", err)
+	}
+}

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -11,15 +11,19 @@ import (
 
 func newInstallCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "install <tool@version>",
+		Use:   "install <tool[@version]>",
 		Short: "Install a tool version",
-		Long:  "Download and install a specific tool version.\n\nExamples:\n  driftr install node@24\n  driftr install pnpm@9\n  driftr install yarn@1\n  driftr install node@latest",
+		Long:  "Download and install a tool version.\n\nA bare tool name installs the newest release.\n\nExamples:\n  driftr install pnpm        # latest pnpm\n  driftr install node        # latest node\n  driftr install node@24\n  driftr install pnpm@9\n  driftr install yarn@1\n  driftr install node@latest",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			spec := args[0]
-			tool, versionSpec := parseToolVersion(spec)
+			tool, versionSpec := parseToolVersion(args[0])
+			// A bare tool name ("driftr install pnpm") has no version — install
+			// the newest release.
+			if versionSpec == "" {
+				versionSpec = "latest"
+			}
 
-			fmt.Println(ioutil.Dim(fmt.Sprintf("Installing %s...", spec)))
+			fmt.Println(ioutil.Dim(fmt.Sprintf("Installing %s@%s...", tool, versionSpec)))
 
 			resolved, err := installTool(tool, versionSpec, verbose)
 			if err != nil {

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -16,10 +17,16 @@ func newInstallCmd() *cobra.Command {
 		Long:  "Download and install a tool version.\n\nA bare tool name installs the newest release.\n\nExamples:\n  driftr install pnpm        # latest pnpm\n  driftr install node        # latest node\n  driftr install node@24\n  driftr install pnpm@9\n  driftr install yarn@1\n  driftr install node@latest",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			tool, versionSpec := parseToolVersion(args[0])
-			// A bare tool name ("driftr install pnpm") has no version — install
-			// the newest release.
+			raw := args[0]
+			tool, versionSpec := parseToolVersion(raw)
 			if versionSpec == "" {
+				// "tool@" is a malformed spec (the user wrote "@" but omitted the
+				// version); reject it rather than silently installing latest. A
+				// bare tool name ("driftr install pnpm") has no "@" and means
+				// "install the newest release".
+				if strings.Contains(raw, "@") {
+					return fmt.Errorf("version required after '@'. Use 'driftr install %s' for the latest, or '%s@<version>'", tool, tool)
+				}
 				versionSpec = "latest"
 			}
 

--- a/internal/cli/parse.go
+++ b/internal/cli/parse.go
@@ -10,8 +10,14 @@ import (
 //
 // When no "@" is present the token is ambiguous: it can be a tool name
 // ("pnpm") or a bare node version ("24", "latest"). A token that matches a
-// known tool resolves to that tool with an empty version (callers default the
-// empty version to "latest"); anything else is treated as a node version.
+// known tool resolves to that tool with an empty version; anything else is
+// treated as a node version.
+//
+// An empty returned version is left for the caller to interpret — it does not
+// imply "latest". Callers decide: install treats it as the latest release,
+// while uninstall requires an explicit version. Note that a bare tool name and
+// an explicit-but-empty spec ("pnpm" vs "pnpm@") both yield an empty version;
+// callers that care about the difference must inspect the raw argument.
 func parseToolVersion(spec string) (string, string) {
 	if tool, ver, ok := strings.Cut(spec, "@"); ok {
 		return tool, ver

--- a/internal/cli/parse.go
+++ b/internal/cli/parse.go
@@ -1,12 +1,23 @@
 package cli
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/DriftrLabs/driftr/internal/platform"
+)
 
 // parseToolVersion splits "node@24.0.0" into ("node", "24.0.0").
-// If no "@" is present, defaults to tool "node".
+//
+// When no "@" is present the token is ambiguous: it can be a tool name
+// ("pnpm") or a bare node version ("24", "latest"). A token that matches a
+// known tool resolves to that tool with an empty version (callers default the
+// empty version to "latest"); anything else is treated as a node version.
 func parseToolVersion(spec string) (string, string) {
 	if tool, ver, ok := strings.Cut(spec, "@"); ok {
 		return tool, ver
+	}
+	if _, ok := platform.LookupTool(spec); ok {
+		return spec, ""
 	}
 	return "node", spec
 }

--- a/internal/cli/parse_test.go
+++ b/internal/cli/parse_test.go
@@ -18,6 +18,12 @@ func TestParseToolVersion(t *testing.T) {
 		{"24", "node", "24"},
 		{"latest", "node", "latest"},
 		{"node@v24.0.0", "node", "v24.0.0"},
+		// Bare tool names resolve to that tool with no version (caller defaults
+		// to latest), not to a node version named after the tool.
+		{"pnpm", "pnpm", ""},
+		{"yarn", "yarn", ""},
+		{"node", "node", ""},
+		{"npm", "npm", ""},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
`driftr install pnpm` (and `node`, `yarn`) failed with:

```
Error: installation failed: invalid version: invalid major version "pnpm": strconv.Atoi: parsing "pnpm": invalid syntax
```

A bare token with no `@` was always treated as a node version, so the tool name was parsed as a version string.

## Fix
- `parseToolVersion`: a token matching a known tool (node/pnpm/yarn/…) now resolves to `(tool, "")` instead of `("node", token)`. Other tokens (`24`, `latest`) still resolve to a node version.
- `install`: an empty version defaults to `latest`.

Now `driftr install pnpm` installs the newest pnpm, `driftr install node` the newest node, etc. Versioned installs (`pnpm@9`, `node@24`, bare `24`) are unchanged.

## Tests
- `parseToolVersion` cases for bare `pnpm`/`yarn`/`node`/`npm`.
- Verified end-to-end: `driftr install pnpm` → pnpm 11.7.0, `driftr install node` → node 26.3.0.
- README + `install --help` document the bare-name behavior.