### PR TITLE
feat: detect PATH shadowing of driftr shims in doctor

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -50,6 +50,7 @@ func newDoctorCmd() *cobra.Command {
 			}
 
 			issues += checkPath(binDir)
+			issues += checkShimShadowing(binDir)
 			issues += checkShellRCPlacement(binDir, fix)
 			issues += checkShims(binDir)
 			issues += checkShimBinaryPath(binDir)
@@ -81,16 +82,56 @@ func warn(msg string) {
 }
 
 func checkPath(binDir string) int {
+	if binDirOnPath(binDir) {
+		pass(binDir + " is on PATH")
+		return 0
+	}
+	warn(binDir + " is not on PATH — shims won't be found")
+	return 1
+}
+
+// binDirOnPath reports whether binDir appears as a PATH entry.
+func binDirOnPath(binDir string) bool {
 	cleanBinDir := filepath.Clean(binDir)
 	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
 		if filepath.Clean(dir) == cleanBinDir {
-			pass(binDir + " is on PATH")
-			return 0
+			return true
 		}
 	}
+	return false
+}
 
-	warn(binDir + " is not on PATH — shims won't be found")
-	return 1
+// checkShimShadowing detects when a managed tool resolves to a binary that is
+// not driftr's shim — i.e. another install (Homebrew, Volta, asdf, …) sits
+// earlier in PATH and wins. driftr can pin and resolve correctly, but the
+// shadowing binary is what the shell actually runs, so the pin appears ignored.
+//
+// Only runs when the shim dir is on PATH at all; otherwise checkPath already
+// reported the root problem and this would be redundant noise.
+func checkShimShadowing(binDir string) int {
+	if !binDirOnPath(binDir) {
+		return 0
+	}
+
+	shimDir := filepath.Clean(binDir)
+	shadowed := 0
+	for _, tool := range versionedTools {
+		resolved, err := exec.LookPath(tool)
+		if err != nil {
+			continue // tool not on PATH anywhere — nothing to shadow
+		}
+		if filepath.Dir(filepath.Clean(resolved)) == shimDir {
+			continue // driftr shim wins
+		}
+		warn(fmt.Sprintf("%s resolves to %s, not the driftr shim — pins/defaults won't apply", tool, resolved))
+		shadowed++
+	}
+
+	if shadowed > 0 {
+		warn("  another install earlier in PATH is shadowing driftr — put ~/.driftr/bin first")
+		warn("  (e.g. append the PATH export to the end of ~/.zshrc, or remove the conflicting tool)")
+	}
+	return shadowed
 }
 
 // checkShellRCPlacement verifies that binDir is exported from a shell rc file

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -128,8 +128,7 @@ func checkShimShadowing(binDir string) int {
 	}
 
 	if shadowed > 0 {
-		warn("  another install earlier in PATH is shadowing driftr — put ~/.driftr/bin first")
-		warn("  (e.g. append the PATH export to the end of ~/.zshrc, or remove the conflicting tool)")
+		warn("  ensure " + binDir + " appears earlier in PATH than the conflicting install, or remove that tool")
 	}
 	return shadowed
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeExe creates an executable file named tool in dir.
+func writeExe(t *testing.T, dir, tool string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, tool), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCheckShimShadowing_ShimWins(t *testing.T) {
+	shimDir := t.TempDir()
+	writeExe(t, shimDir, "node")
+	t.Setenv("PATH", shimDir)
+
+	if got := checkShimShadowing(shimDir); got != 0 {
+		t.Errorf("shim is first on PATH, want 0 shadowed, got %d", got)
+	}
+}
+
+func TestCheckShimShadowing_OtherInstallShadows(t *testing.T) {
+	shimDir := t.TempDir()
+	otherDir := t.TempDir()
+	writeExe(t, shimDir, "node")
+	writeExe(t, otherDir, "node") // earlier in PATH → wins
+	t.Setenv("PATH", otherDir+string(os.PathListSeparator)+shimDir)
+
+	if got := checkShimShadowing(shimDir); got != 1 {
+		t.Errorf("node shadowed by earlier install, want 1, got %d", got)
+	}
+}
+
+func TestCheckShimShadowing_SkipsWhenBinDirNotOnPath(t *testing.T) {
+	shimDir := t.TempDir()
+	otherDir := t.TempDir()
+	writeExe(t, otherDir, "node")
+	// shimDir absent from PATH — checkPath owns that diagnosis, so shadowing
+	// check must stay silent (return 0).
+	t.Setenv("PATH", otherDir)
+
+	if got := checkShimShadowing(shimDir); got != 0 {
+		t.Errorf("bin dir not on PATH, want 0 (skip), got %d", got)
+	}
+}
+
+func TestCheckShimShadowing_NoToolsOnPath(t *testing.T) {
+	shimDir := t.TempDir() // on PATH but contains no tool binaries
+	t.Setenv("PATH", shimDir)
+
+	if got := checkShimShadowing(shimDir); got != 0 {
+		t.Errorf("no managed tools on PATH, want 0, got %d", got)
+	}
+}


### PR DESCRIPTION
## Problem
A user pinned `node@24` but `node -v` still showed the system version. Root cause was not a driftr bug — Homebrew's `/opt/homebrew/bin` and Volta's `~/.volta/bin` sit earlier in PATH than `~/.driftr/bin`, so their `node` wins and driftr's shim never runs. `driftr doctor` didn't catch it: it only checked that the shim dir is *present* on PATH, not whether another install *shadows* it.

## Change
`doctor` now resolves each managed tool (node/pnpm/yarn) via `exec.LookPath` and compares the winning binary's directory to the shim dir. When they differ it warns:

```
!!  node resolves to /opt/homebrew/bin/node, not the driftr shim — pins/defaults won't apply
!!    another install earlier in PATH is shadowing driftr — put ~/.driftr/bin first
!!    (e.g. append the PATH export to the end of ~/.zshrc, or remove the conflicting tool)
```

This is broader than the existing fixed `fnm/volta/n` manager-name list — it catches *any* shadowing install (Homebrew, asdf, a stray `/usr/local/bin/node`, etc.).

- Only runs when the shim dir is on PATH (otherwise `checkPath` already reports the root issue — avoids duplicate noise).
- Extracts a shared `binDirOnPath` helper.

## Tests
- shim wins → 0 issues
- earlier install shadows → 1 issue + remediation
- bin dir not on PATH → skipped
- no managed tools on PATH → 0
- Verified against a real Homebrew+Volta+driftr PATH.