### PR TITLE
fix: configure PATH in driftr setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ brew tap DriftrLabs/driftr
 brew install driftr
 ```
 
-After installing, run `driftr setup` and add `~/.driftr/bin` to the front of your PATH. See [docs/installation.md](docs/installation.md) for the required PATH setup and why it matters on macOS.
+After installing, run `driftr setup` — it generates the shims and configures your shell PATH automatically (writing to a universally-sourced rc file such as `~/.zshenv`). Restart your shell afterwards. See [docs/installation.md](docs/installation.md) for details and why PATH ordering matters on macOS.
 
 ### Quick Install (curl)
 
@@ -86,7 +86,7 @@ pnpm -v   # resolves automatically
 | `driftr list --remote [tool]` | Browse available remote versions from nodejs.org / npm registry |
 | `driftr which <tool>` | Show which binary would be executed and why |
 | `driftr run --node <ver> -- <cmd>` | Run a command under a specific Node.js version |
-| `driftr setup` | Initialize Driftr and generate shims |
+| `driftr setup` | Initialize Driftr, generate shims, and configure your shell PATH |
 | `driftr cache clean` | Remove all cached downloads to free disk space |
 | `driftr cache dir` | Print the cache directory path |
 | `driftr self-update` | Update Driftr to the latest version |

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -242,6 +242,30 @@ func TestListCmd_Empty(t *testing.T) {
 	}
 }
 
+func TestSetupCmd_ConfiguresPathInUniversalRcFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("SHELL", "/bin/zsh")
+
+	if err := runCmd(t, "setup"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// zsh's universal rc file is .zshenv (sourced by every shell), not the
+	// interactive-only .zshrc.
+	zshenv := filepath.Join(home, ".zshenv")
+	data, err := os.ReadFile(zshenv)
+	if err != nil {
+		t.Fatalf("expected PATH written to .zshenv: %v", err)
+	}
+	if !strings.Contains(string(data), filepath.Join(home, ".driftr", "bin")) {
+		t.Errorf(".zshenv missing driftr bin PATH export: %q", data)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".zshrc")); err == nil {
+		t.Errorf("setup must not create/use interactive-only .zshrc")
+	}
+}
+
 func TestInstallCmd_TrailingAtErrors(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -2,10 +2,13 @@ package cli
 
 import (
 	"fmt"
+	"io"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/DriftrLabs/driftr/internal/ioutil"
+	"github.com/DriftrLabs/driftr/internal/pathsetup"
 	"github.com/DriftrLabs/driftr/internal/platform"
 	"github.com/DriftrLabs/driftr/internal/shim"
 )
@@ -14,7 +17,7 @@ func newSetupCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "setup",
 		Short: "Initialize Driftr directories and generate shims",
-		Long:  "Create the Driftr directory structure and generate shim scripts.\nAfter running setup, add ~/.driftr/bin to your PATH.",
+		Long:  "Create the Driftr directory structure, generate shim scripts, and configure\nyour shell PATH so the shims are found.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := platform.EnsureDirs(); err != nil {
 				return fmt.Errorf("failed to create directories: %w", err)
@@ -29,15 +32,55 @@ func newSetupCmd() *cobra.Command {
 				return err
 			}
 
-			fmt.Println(ioutil.Success(ioutil.Bold("Driftr setup complete!")))
-			fmt.Println()
-			fmt.Println("Add the following to your shell profile (~/.zshrc, ~/.bashrc, etc.):")
-			fmt.Println()
-			fmt.Printf("  %s\n", ioutil.Bold(fmt.Sprintf("export PATH=\"%s:$PATH\"", binDir)))
-			fmt.Println()
-			fmt.Println(ioutil.Dim("Then restart your shell or run: source ~/.zshrc"))
-
+			fmt.Fprintln(cmd.OutOrStdout(), ioutil.Success(ioutil.Bold("Driftr setup complete!")))
+			fmt.Fprintln(cmd.OutOrStdout())
+			configureSetupPath(cmd.OutOrStdout(), binDir)
 			return nil
 		},
 	}
+}
+
+// configureSetupPath sets up the shell PATH the same way `doctor --fix` and
+// `self-update` do — writing to the rc file every shell invocation sources
+// (e.g. ~/.zshenv) rather than an interactive-only file like ~/.zshrc. On any
+// failure it falls back to shell-agnostic manual instructions.
+func configureSetupPath(w io.Writer, binDir string) {
+	r, err := pathsetup.Detect(binDir)
+	if err != nil {
+		manualPathInstructions(w, binDir)
+		return
+	}
+
+	if !r.NeedsFix() {
+		fmt.Fprintln(w, ioutil.Success(fmt.Sprintf("PATH already configured in %s", r.Target)))
+		printStaleNote(w, r)
+		fmt.Fprintln(w, ioutil.Dim(fmt.Sprintf("Restart your shell or run: source %s", r.Target)))
+		return
+	}
+
+	wrote, file, applyErr := pathsetup.Apply(r)
+	if applyErr != nil || !wrote {
+		manualPathInstructions(w, binDir)
+		return
+	}
+
+	fmt.Fprintln(w, ioutil.Success(fmt.Sprintf("Added %s to PATH in %s", binDir, file)))
+	printStaleNote(w, r)
+	fmt.Fprintln(w, ioutil.Dim("Restart your shell to start using driftr."))
+}
+
+func printStaleNote(w io.Writer, r pathsetup.Result) {
+	if len(r.StaleFiles) > 0 {
+		fmt.Fprintln(w, ioutil.Dim(fmt.Sprintf("  Note: legacy entries remain in %s — safe to remove.", strings.Join(r.StaleFiles, ", "))))
+	}
+}
+
+// manualPathInstructions prints shell-agnostic fallback guidance when driftr
+// can't determine or write the rc file (e.g. unknown shell).
+func manualPathInstructions(w io.Writer, binDir string) {
+	fmt.Fprintln(w, "Add the following to your shell profile so the shims are found:")
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "  %s\n", ioutil.Bold(fmt.Sprintf("export PATH=\"%s:$PATH\"", binDir)))
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, ioutil.Dim("Then restart your shell."))
 }


### PR DESCRIPTION
## Problem
`driftr setup` printed:
```
Add the following to your shell profile (~/.zshrc, ~/.bashrc, etc.):
  export PATH="/Users/.../.driftr/bin:$PATH"
Then restart your shell or run: source ~/.zshrc
```
This contradicts driftr's own PATH strategy. `install.sh`, `doctor --fix`, and `self-update` all configure a **universally-sourced** rc file (e.g. `~/.zshenv`) so non-interactive shells, scripts, and IDE subprocesses also find the shims. `doctor` even flags interactive-only `~/.zshrc` as insufficient — so `setup` was telling users to do the exact thing `doctor` warns against.

## Fix
`setup` now uses `pathsetup.Detect`/`Apply` like the sibling commands:
- writes the PATH export to the correct rc file, idempotently
- reports when PATH is already configured (no duplicate writes)
- notes stale interactive-only entries that are safe to remove
- falls back to shell-agnostic manual guidance when the shell is unknown

Example:
```
✓ Driftr setup complete!

✓ Added /Users/.../.driftr/bin to PATH in /Users/.../.zshenv
Restart your shell to start using driftr.
```

## Tests
- New: `setup` writes to `.zshenv` (not `.zshrc`) for zsh.
- Verified: first run writes, second run reports already-configured, unknown shell falls back, README updated.