### PR TITLE
feat: add PATH precedence guard for shadowed shims

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -73,7 +73,7 @@ echo 'export PATH="$HOME/.driftr/bin:$PATH"' >> ~/.zshrc
 echo 'export PATH="$HOME/.driftr/bin:$PATH"' >> ~/.bash_profile
 ```
 
-Or run `driftr doctor --fix` to configure PATH automatically for your shell. Run `driftr doctor` to verify your setup.
+Or let Driftr do it for you: `driftr setup` and `driftr doctor --fix` both configure the universal file *and*, when they detect that another install (Homebrew, Volta, …) is shadowing the shims, append a PATH precedence guard to your interactive rc (`~/.zshrc`, `~/.bashrc`, or fish `config.fish`) so the shims win. Run `driftr doctor` to verify your setup.
 
 ### Upgrading
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -50,7 +50,7 @@ func newDoctorCmd() *cobra.Command {
 			}
 
 			issues += checkPath(binDir)
-			issues += checkShimShadowing(binDir)
+			issues += checkShimShadowing(binDir, fix)
 			issues += checkShellRCPlacement(binDir, fix)
 			issues += checkShims(binDir)
 			issues += checkShimBinaryPath(binDir)
@@ -108,13 +108,21 @@ func binDirOnPath(binDir string) bool {
 //
 // Only runs when the shim dir is on PATH at all; otherwise checkPath already
 // reported the root problem and this would be redundant noise.
-func checkShimShadowing(binDir string) int {
-	if !binDirOnPath(binDir) {
-		return 0
-	}
+// shadowedShim records a managed tool whose resolved binary is not the shim.
+type shadowedShim struct {
+	tool     string
+	resolved string
+}
 
+// shadowedShims returns the managed tools that resolve to a non-shim binary
+// because another install sits earlier in PATH. Empty when the shim dir is not
+// on PATH (checkPath owns that case) or nothing is shadowed.
+func shadowedShims(binDir string) []shadowedShim {
+	if !binDirOnPath(binDir) {
+		return nil
+	}
 	shimDir := filepath.Clean(binDir)
-	shadowed := 0
+	var shadows []shadowedShim
 	for _, tool := range versionedTools {
 		resolved, err := exec.LookPath(tool)
 		if err != nil {
@@ -123,14 +131,45 @@ func checkShimShadowing(binDir string) int {
 		if filepath.Dir(filepath.Clean(resolved)) == shimDir {
 			continue // driftr shim wins
 		}
-		warn(fmt.Sprintf("%s resolves to %s, not the driftr shim — pins/defaults won't apply", tool, resolved))
-		shadowed++
+		shadows = append(shadows, shadowedShim{tool: tool, resolved: resolved})
+	}
+	return shadows
+}
+
+// checkShimShadowing detects when a managed tool resolves to a binary that is
+// not driftr's shim — i.e. another install (Homebrew, Volta, asdf, …) sits
+// earlier in PATH and wins. driftr can pin and resolve correctly, but the
+// shadowing binary is what the shell actually runs, so the pin appears ignored.
+//
+// With fix=true it repairs the situation by appending a PATH precedence guard
+// to the interactive rc file (see pathsetup.ApplyGuard).
+func checkShimShadowing(binDir string, fix bool) int {
+	shadows := shadowedShims(binDir)
+	if len(shadows) == 0 {
+		return 0
+	}
+	for _, s := range shadows {
+		warn(fmt.Sprintf("%s resolves to %s, not the driftr shim — pins/defaults won't apply", s.tool, s.resolved))
 	}
 
-	if shadowed > 0 {
-		warn("  ensure " + binDir + " appears earlier in PATH than the conflicting install, or remove that tool")
+	if !fix {
+		warn("  run `driftr doctor --fix` to add a PATH precedence guard, or remove the conflicting tool")
+		return 1
 	}
-	return shadowed
+
+	wrote, file, err := pathsetup.ApplyGuard(pathsetup.DetectShell(), binDir)
+	if err != nil {
+		warn("  fix failed: " + err.Error())
+		return 1
+	}
+	if wrote {
+		pass(fmt.Sprintf("  fixed: added PATH precedence guard to %s (open a new shell to apply)", file))
+		return 0
+	}
+	// Guard already present but the tool is still shadowed: PATH in this session
+	// is stale (rc not re-sourced) or another tool prepends after the guard.
+	warn("  precedence guard already present — restart your shell, or ensure " + binDir + " is exported last")
+	return 1
 }
 
 // checkShellRCPlacement verifies that binDir is exported from a shell rc file

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -22,7 +23,7 @@ func TestCheckShimShadowing_ShimWins(t *testing.T) {
 	writeExe(t, shimDir, "node")
 	t.Setenv("PATH", shimDir)
 
-	if got := checkShimShadowing(shimDir); got != 0 {
+	if got := checkShimShadowing(shimDir, false); got != 0 {
 		t.Errorf("shim is first on PATH, want 0 shadowed, got %d", got)
 	}
 }
@@ -34,7 +35,7 @@ func TestCheckShimShadowing_OtherInstallShadows(t *testing.T) {
 	writeExe(t, otherDir, "node") // earlier in PATH → wins
 	t.Setenv("PATH", otherDir+string(os.PathListSeparator)+shimDir)
 
-	if got := checkShimShadowing(shimDir); got != 1 {
+	if got := checkShimShadowing(shimDir, false); got != 1 {
 		t.Errorf("node shadowed by earlier install, want 1, got %d", got)
 	}
 }
@@ -47,7 +48,7 @@ func TestCheckShimShadowing_SkipsWhenBinDirNotOnPath(t *testing.T) {
 	// check must stay silent (return 0).
 	t.Setenv("PATH", otherDir)
 
-	if got := checkShimShadowing(shimDir); got != 0 {
+	if got := checkShimShadowing(shimDir, false); got != 0 {
 		t.Errorf("bin dir not on PATH, want 0 (skip), got %d", got)
 	}
 }
@@ -56,7 +57,32 @@ func TestCheckShimShadowing_NoToolsOnPath(t *testing.T) {
 	shimDir := t.TempDir() // on PATH but contains no tool binaries
 	t.Setenv("PATH", shimDir)
 
-	if got := checkShimShadowing(shimDir); got != 0 {
+	if got := checkShimShadowing(shimDir, false); got != 0 {
 		t.Errorf("no managed tools on PATH, want 0, got %d", got)
+	}
+}
+
+func TestCheckShimShadowing_FixAppendsGuardToZshrc(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("ZDOTDIR", "")
+	t.Setenv("SHELL", "/bin/zsh")
+
+	shimDir := filepath.Join(home, ".driftr", "bin")
+	otherDir := t.TempDir()
+	writeExe(t, shimDir, "node")
+	writeExe(t, otherDir, "node") // shadows the shim
+	t.Setenv("PATH", otherDir+string(os.PathListSeparator)+shimDir)
+
+	// fix=true resolves the shadow by writing a precedence guard → 0 issues.
+	if got := checkShimShadowing(shimDir, true); got != 0 {
+		t.Errorf("with --fix the guard should resolve shadowing, got %d issues", got)
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".zshrc"))
+	if err != nil {
+		t.Fatalf("expected guard written to .zshrc: %v", err)
+	}
+	if !strings.Contains(string(data), shimDir) || !strings.Contains(string(data), "precedence guard") {
+		t.Errorf(".zshrc missing precedence guard: %q", data)
 	}
 }

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -54,6 +54,7 @@ func configureSetupPath(w io.Writer, binDir string) {
 	if !r.NeedsFix() {
 		fmt.Fprintln(w, ioutil.Success(fmt.Sprintf("PATH already configured in %s", r.Target)))
 		printStaleNote(w, r)
+		applyShadowGuard(w, binDir)
 		fmt.Fprintln(w, ioutil.Dim(fmt.Sprintf("Restart your shell or run: source %s", r.Target)))
 		return
 	}
@@ -66,7 +67,23 @@ func configureSetupPath(w io.Writer, binDir string) {
 
 	fmt.Fprintln(w, ioutil.Success(fmt.Sprintf("Added %s to PATH in %s", binDir, file)))
 	printStaleNote(w, r)
+	applyShadowGuard(w, binDir)
 	fmt.Fprintln(w, ioutil.Dim("Restart your shell to start using driftr."))
+}
+
+// applyShadowGuard adds a PATH precedence guard to the interactive rc file when
+// a managed tool is currently shadowed by another install earlier in PATH
+// (Homebrew, Volta, …). The universal config alone can't win in that case
+// because those tools re-prepend their dirs during interactive startup.
+func applyShadowGuard(w io.Writer, binDir string) {
+	if len(shadowedShims(binDir)) == 0 {
+		return
+	}
+	wrote, file, err := pathsetup.ApplyGuard(pathsetup.DetectShell(), binDir)
+	if err != nil || !wrote {
+		return
+	}
+	fmt.Fprintln(w, ioutil.Success(fmt.Sprintf("Added a PATH precedence guard to %s (another install was shadowing driftr)", file)))
 }
 
 func printStaleNote(w io.Writer, r pathsetup.Result) {

--- a/internal/pathsetup/pathsetup.go
+++ b/internal/pathsetup/pathsetup.go
@@ -129,6 +129,92 @@ func Apply(r Result) (wrote bool, target string, err error) {
 	return true, r.Target, nil
 }
 
+// GuardProfile returns the interactive rc file that is sourced *last* for the
+// shell — the right place for a PATH "precedence guard" that must win over
+// dirs prepended by other tools (Homebrew, Volta) during interactive startup.
+//
+// This differs from TargetProfile (the universally-sourced file): the target
+// guarantees coverage in non-interactive shells, while the guard guarantees
+// precedence in interactive ones. Returns "" for shells where no guard applies.
+func GuardProfile(shell Shell) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("home dir: %w", err)
+	}
+
+	switch shell {
+	case ShellZsh:
+		zdotdir := os.Getenv("ZDOTDIR")
+		if zdotdir == "" {
+			zdotdir = home
+		}
+		return filepath.Join(zdotdir, ".zshrc"), nil
+	case ShellBash:
+		return filepath.Join(home, ".bashrc"), nil
+	case ShellFish:
+		base := os.Getenv("XDG_CONFIG_HOME")
+		if base == "" {
+			base = filepath.Join(home, ".config")
+		}
+		return filepath.Join(base, "fish", "config.fish"), nil
+	default:
+		return "", nil
+	}
+}
+
+// ApplyGuard appends a PATH precedence guard to the shell's interactive rc file
+// (see GuardProfile). It is idempotent: if the file already exports binDir, it
+// writes nothing. Returns (true, file) when it wrote, (false, "") otherwise.
+//
+// Use only when binDir is on PATH but shadowed by an earlier entry — appending
+// the export last lets driftr's shims win. The universal config (Apply) is
+// still required for non-interactive coverage.
+func ApplyGuard(shell Shell, binDir string) (wrote bool, file string, err error) {
+	guard, err := GuardProfile(shell)
+	if err != nil {
+		return false, "", err
+	}
+	if guard == "" {
+		return false, "", nil
+	}
+
+	mentioned, err := fileMentionsAny(guard, binDirNeedles(binDir))
+	if err != nil {
+		return false, "", err
+	}
+	if mentioned {
+		return false, "", nil // already present — nothing to do
+	}
+
+	if err = os.MkdirAll(filepath.Dir(guard), 0o755); err != nil {
+		return false, "", fmt.Errorf("create profile dir: %w", err)
+	}
+
+	f, ferr := os.OpenFile(guard, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if ferr != nil {
+		return false, "", fmt.Errorf("open %s: %w", guard, ferr)
+	}
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("close %s: %w", guard, cerr)
+			wrote = false
+			file = ""
+		}
+	}()
+
+	info, _ := f.Stat()
+	prefix := "\n"
+	if info != nil && info.Size() == 0 {
+		prefix = ""
+	}
+	line := exportLine(shell, binDir)
+	if _, werr := fmt.Fprintf(f, "%s# Driftr (precedence guard — keep last)\n%s\n", prefix, line); werr != nil {
+		return false, "", fmt.Errorf("write %s: %w", guard, werr)
+	}
+
+	return true, guard, nil
+}
+
 // DetectShell returns the user's shell based on $SHELL, defaulting to unknown.
 func DetectShell() Shell {
 	sh := os.Getenv("SHELL")

--- a/internal/pathsetup/pathsetup_test.go
+++ b/internal/pathsetup/pathsetup_test.go
@@ -317,6 +317,79 @@ func TestDetect_InProcessPATH(t *testing.T) {
 	}
 }
 
+func TestGuardProfile(t *testing.T) {
+	home := setHome(t)
+	cases := map[Shell]string{
+		ShellZsh:     filepath.Join(home, ".zshrc"),
+		ShellBash:    filepath.Join(home, ".bashrc"),
+		ShellFish:    filepath.Join(home, ".config", "fish", "config.fish"),
+		ShellUnknown: "",
+	}
+	for shell, want := range cases {
+		got, err := GuardProfile(shell)
+		if err != nil {
+			t.Fatalf("%s: %v", shell, err)
+		}
+		if got != want {
+			t.Errorf("GuardProfile(%s) = %q, want %q", shell, got, want)
+		}
+	}
+}
+
+func TestApplyGuard_AppendsToInteractiveRc(t *testing.T) {
+	home := setHome(t)
+	binDir := filepath.Join(home, ".driftr", "bin")
+	zshrc := filepath.Join(home, ".zshrc")
+	writeFile(t, zshrc, "eval \"$(/opt/homebrew/bin/brew shellenv)\"\n")
+
+	wrote, file, err := ApplyGuard(ShellZsh, binDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !wrote || file != zshrc {
+		t.Fatalf("ApplyGuard wrote=%v file=%q, want true %q", wrote, file, zshrc)
+	}
+
+	content := readFile(t, zshrc)
+	// Guard must come AFTER the brew line to win precedence.
+	brewIdx := strings.Index(content, "brew shellenv")
+	guardIdx := strings.Index(content, "export PATH=\""+binDir+":$PATH\"")
+	if brewIdx < 0 || guardIdx < 0 || guardIdx < brewIdx {
+		t.Errorf("guard must be appended after existing content:\n%s", content)
+	}
+	if !strings.Contains(content, "precedence guard") {
+		t.Errorf("missing guard marker:\n%s", content)
+	}
+}
+
+func TestApplyGuard_Idempotent(t *testing.T) {
+	home := setHome(t)
+	binDir := filepath.Join(home, ".driftr", "bin")
+	zshrc := filepath.Join(home, ".zshrc")
+	writeFile(t, zshrc, "export PATH=\""+binDir+":$PATH\"\n")
+
+	wrote, _, err := ApplyGuard(ShellZsh, binDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wrote {
+		t.Error("ApplyGuard wrote when binDir already exported in guard file")
+	}
+}
+
+func TestApplyGuard_UnknownShellNoOp(t *testing.T) {
+	home := setHome(t)
+	binDir := filepath.Join(home, ".driftr", "bin")
+
+	wrote, file, err := ApplyGuard(ShellUnknown, binDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wrote || file != "" {
+		t.Errorf("ApplyGuard(unknown) wrote=%v file=%q, want no-op", wrote, file)
+	}
+}
+
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {


### PR DESCRIPTION
## Problem
When another install (Homebrew, Volta, asdf) sits earlier in PATH, driftr's shims are shadowed even though `~/.driftr/bin` is "configured" — those tools re-prepend their dirs in interactive rc files (`~/.zshrc`/`~/.zprofile`) that are sourced **after** `~/.zshenv`. driftr resolved pins correctly, but the shell ran the wrong binary (this is what bit a user: `driftr pin node@24` had no effect because Homebrew's node won).

`setup`/`doctor --fix` previously only wrote the universal file (`~/.zshenv`), which can't win that race.

## Fix — conditional precedence guard
`setup` and `doctor --fix` now detect shadowing (the existing `exec.LookPath` check) and, **only when a shim is actually shadowed**, append a PATH precedence guard to the interactive rc that is sourced last (`~/.zshrc`, `~/.bashrc`, fish `config.fish`). Being last, it wins over Homebrew/Volta prepends. The `~/.zshenv` config still provides non-interactive coverage.

Clean `.zshenv`-only setup remains for users without conflicts — the guard is added only when needed.

```
$ driftr doctor --fix
  !!  node resolves to /opt/homebrew/bin/node, not the driftr shim — pins/defaults won't apply
  ok    fixed: added PATH precedence guard to ~/.zshrc (open a new shell to apply)
```

## Components
- `pathsetup`: `GuardProfile(shell)` + `ApplyGuard(shell, binDir)` — idempotent, appends the export last with a `# Driftr (precedence guard — keep last)` marker.
- `doctor`: extracted `shadowedShims`; `checkShimShadowing(binDir, fix)` applies the guard under `--fix`.
- `setup`: applies the guard when a shim is shadowed (it already auto-writes `~/.zshenv`).
- No `scanStale` change needed — `checkShellRCPlacement` already passes when the universal file is configured, so the guard in `~/.zshrc` raises no false "stale" warning.

## Tests
- `pathsetup`: `GuardProfile` per shell; `ApplyGuard` appends after existing content, idempotent, unknown-shell no-op.
- `cli`: `--fix` writes the guard to `.zshrc` and clears the issue; existing shadowing tests updated.
- Verified end-to-end with a simulated Homebrew-shadows-node PATH.

## Out of scope
`install.sh` (shell script) — docs already cover the manual two-file setup; standalone users get `~/.zshenv` and can run `doctor --fix`.