### PR TITLE
fix: bake stable binary path into shims

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,6 +79,8 @@ Shims are simple shell scripts:
 exec "/usr/local/bin/driftr" shim node "$@"
 ```
 
+The baked path is the path `driftr` was invoked with (`os.Executable()`), **not** the symlink-resolved target. This matters for package-manager installs: Homebrew exposes a stable symlink (`/opt/homebrew/bin/driftr`) pointing at a version-pinned file (`.../Cellar/driftr/0.11.1/bin/driftr`). Baking the resolved path would dangle every shim on the next `brew upgrade`; baking the stable symlink survives upgrades.
+
 Shims exist for `node`, `npm`, `npx`, `pnpm`, `pnpx`, and `yarn`. The `exec` replaces the shell process with `driftr`, and then `driftr` uses `syscall.Exec` to replace itself with the real binary. This double-exec means:
 
 - No child process management

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -32,11 +32,16 @@ func GenerateShims() error {
 	if err != nil {
 		return fmt.Errorf("cannot determine driftr executable path: %w", err)
 	}
-	// Resolve symlinks to get the real path.
-	driftrBin, err = filepath.EvalSymlinks(driftrBin)
-	if err != nil {
-		return fmt.Errorf("cannot resolve driftr executable path: %w", err)
-	}
+	// Intentionally do NOT resolve symlinks here. Package managers like
+	// Homebrew expose a stable symlink (e.g. /opt/homebrew/bin/driftr) that
+	// points at a version-pinned target (.../Cellar/driftr/0.11.1/bin/driftr).
+	// Resolving the symlink bakes the version-pinned path into every shim, so
+	// the next `brew upgrade` deletes that directory and leaves the shims
+	// dangling ("No such file or directory"). os.Executable() already returns
+	// the path the process was invoked with — the stable symlink — which
+	// survives upgrades. An absolute path is also more robust than relying on
+	// PATH, since shims run in non-interactive shells where the driftr install
+	// dir may not be on PATH.
 
 	for _, tool := range shimTools {
 		if err := writeShim(binDir, tool, driftrBin); err != nil {


### PR DESCRIPTION
## Problem
Shims hardcoded the **version-pinned** Homebrew Cellar path (`os.Executable()` + `filepath.EvalSymlinks`). After `brew upgrade`, the old Cellar dir is deleted and every shim dangles:

```
/Users/.../.driftr/bin/node: line 2: /opt/homebrew/Cellar/driftr/0.11.1/bin/driftr: No such file or directory
```

## Fix
- Drop `EvalSymlinks` in `GenerateShims` — `os.Executable()` already returns the stable invocation path (e.g. `/opt/homebrew/bin/driftr`), which survives upgrades.
- Absolute path also beats PATH lookup in non-interactive shells (hooks) where the install dir may be absent from PATH.
- Document the decision in `docs/architecture.md`.

Side benefit: `doctor`'s "Shims point to X but driftr is at Y" warning stops firing spuriously after every upgrade.

## Verify
`go build` / `go vet` / `go test ./...` pass; `gofmt` clean.